### PR TITLE
Feat: Explosives Chart Run/Pass Breakdown

### DIFF
--- a/EXPLOSIVES_CHART_TASK.md
+++ b/EXPLOSIVES_CHART_TASK.md
@@ -1,0 +1,54 @@
+# Explosives Chart Run/Pass Breakdown
+
+## Problem
+The Explosives tab chart shows only total explosives per game. It should show separate lines for rush vs pass explosives to match the table breakdown.
+
+## Data Available
+Each game object has:
+- `explosive_rushes` - count of 15+ yard rushes
+- `explosive_passes` - count of 20+ yard passes
+- `explosives` - total (sum of above)
+
+## Task
+Update `initExplosivesCharts()` function in `index.html` to show 4 lines instead of 2:
+
+**Current (wrong):**
+- Georgia total explosives (red)
+- Arizona State total explosives (orange)
+
+**New (correct):**
+- Georgia rush (green line, solid)
+- Georgia pass (blue line, solid)
+- Arizona State rush (green line, dashed)
+- Arizona State pass (blue line, dashed)
+
+## Implementation Details
+
+**Colors:**
+- Run/rush: green (#22c55e or similar)
+- Pass: blue (#3b82f6 or similar)
+- Use solid lines for Georgia
+- Use dashed lines for Arizona State (lineStyle: {type: 'dashed'})
+
+**Legend:**
+- "Georgia Rush", "Georgia Pass", "Arizona State Rush", "Arizona State Pass"
+
+**Series data:**
+- Georgia rush: `gf.map(g => g.explosive_rushes)`
+- Georgia pass: `gf.map(g => g.explosive_passes)`
+- Arizona State rush: `af.map(g => g.explosive_rushes)`
+- Arizona State pass: `af.map(g => g.explosive_passes)`
+
+**Tooltip:**
+Keep the existing tooltip formatter logic but update to show run/pass breakdown for each team
+
+## File to Edit
+`index.html` - find `function initExplosivesCharts()` (around line 369)
+
+## Acceptance Criteria
+- [ ] Chart shows 4 lines (2 per team: rush + pass)
+- [ ] Colors: green for rush, blue for pass
+- [ ] Solid lines for Georgia, dashed for Arizona State
+- [ ] Legend clearly shows all 4 series
+- [ ] Tooltip shows opponent + date (keep existing logic)
+- [ ] No other changes to the Explosives tab

--- a/index.html
+++ b/index.html
@@ -386,12 +386,14 @@ function initExplosivesCharts() {
                 return tip;
             }
         },
-        legend: { data: ['Georgia', 'Arizona State'], textStyle: { color: '#a1a1aa' } },
+        legend: { data: ['Georgia Rush', 'Georgia Pass', 'Arizona State Rush', 'Arizona State Pass'], textStyle: { color: '#a1a1aa' } },
         xAxis: { type: 'category', data: gf.map((g,i) => 'G'+(i+1)), axisLabel: { color: '#71717a' } },
         yAxis: { type: 'value', axisLabel: { color: '#71717a' }, splitLine: { lineStyle: { color: 'rgba(255,255,255,0.05)' } } },
         series: [
-            { name: 'Georgia', type: 'line', data: gf.map(g => g.explosives), itemStyle: { color: '#ef4444' }, smooth: true },
-            { name: 'Arizona State', type: 'line', data: af.map(g => g.explosives), itemStyle: { color: '#f97316' }, smooth: true }
+            { name: 'Georgia Rush', type: 'line', data: gf.map(g => g.explosive_rushes), itemStyle: { color: '#22c55e' }, lineStyle: { color: '#22c55e' }, smooth: true },
+            { name: 'Georgia Pass', type: 'line', data: gf.map(g => g.explosive_passes), itemStyle: { color: '#3b82f6' }, lineStyle: { color: '#3b82f6' }, smooth: true },
+            { name: 'Arizona State Rush', type: 'line', data: af.map(g => g.explosive_rushes), itemStyle: { color: '#22c55e' }, lineStyle: { color: '#22c55e', type: 'dashed' }, smooth: true },
+            { name: 'Arizona State Pass', type: 'line', data: af.map(g => g.explosive_passes), itemStyle: { color: '#3b82f6' }, lineStyle: { color: '#3b82f6', type: 'dashed' }, smooth: true }
         ]
     });
     window.addEventListener('resize', () => c.resize());


### PR DESCRIPTION
## Changes
- Updated explosives chart to show **4 lines** instead of 2:
  - Georgia Rush (green, solid)
  - Georgia Pass (blue, solid)
  - Arizona State Rush (green, dashed)
  - Arizona State Pass (blue, dashed)
- Updated legend and series data to use `explosive_rushes` and `explosive_passes` fields

## Fixes
Part of Wave 4B item #3

## Note
Based on Codex session (31,972 tokens), manually applied after file-write issue.