### PR TITLE
Fix #72: Display correct rank for reversed stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -943,7 +943,7 @@ function renderStatBadge(rank, total, reverse=false, conference='') {
     else if (adjustedRank > Math.ceil(total * 0.75)) cls = 'bad';
     else if (adjustedRank > Math.ceil(total * 0.5)) cls = 'low';
     const confLabel = conference ? ` in ${conference}` : '';
-    return `<span class="rank-badge ${cls}">${ordinal(rank)}${confLabel}</span>`;
+    return `<span class="rank-badge ${cls}">${ordinal(adjustedRank)}${confLabel}</span>`;
 }
 
 const RANKING_META = {


### PR DESCRIPTION
## Problem
Conference rankings for reversed stats (like penalties, where lower is better) were displaying incorrect rank numbers.

For example, if ASU is ranked 11th in penalty yards (meaning 10 teams have fewer penalties), in a 'lower is better' context they should show as 6th best (16 - 11 + 1 = 6), not 11th.

## Solution
The `renderStatBadge` function was calculating `adjustedRank` for badge color coding but displaying `ordinal(rank)` instead of `ordinal(adjustedRank)`. 

Changed line 946 to use `adjustedRank` in the display, which correctly shows the adjusted rank for reversed stats while keeping normal stats unchanged.

## Testing
- Normal stats (turnover_margin, total_offense, etc.) - rank displays unchanged ✅
- Reversed stats (penalties, sacks_offense, total_defense, etc.) - now show adjusted rank ✅

Fixes #72