### PR TITLE
fix: Oregon/Washington State team name collision

### DIFF
--- a/generate_data.py
+++ b/generate_data.py
@@ -969,10 +969,10 @@ def process_team_games(pdf_dir, team_identifier):
                 if team_identifier == 'georgia' and ('georgia' in stl or 'uga' in stl or our_abbr.lower() in stl):
                     our_idx = idx
                     break
-                if team_identifier == 'oregon' and ('oregon' in stl or our_abbr.lower() in stl):
+                if team_identifier == 'oregon' and ('oregon' in stl or our_abbr.lower() in stl) and 'state' not in stl:
                     our_idx = idx
                     break
-                if team_identifier == 'washington' and ('washington' in stl or 'wash' in stl or our_abbr.lower() in stl):
+                if team_identifier == 'washington' and ('washington' in stl or 'wash' in stl or our_abbr.lower() in stl) and 'state' not in stl:
                     our_idx = idx
                     break
             if our_idx == -1:


### PR DESCRIPTION
## Summary
Fixes team identification bug when Oregon plays Oregon State (or Washington plays Washington State).

## Problem
When matching team names in score extraction, 'oregon' in 'oregon state' matched True, causing:
- Oregon's Game 4 to show 'Oregon' as opponent instead of 'Oregon State'
- Scores swapped (showing 7 instead of 41)

## Fix
Added 'state' exclusion check:
```python
if team_identifier == 'oregon' and ('oregon' in stl) and 'state' not in stl:
```

## Testing
After this fix, Oregon validation should improve from showing 7 points (opponent's score) to 41 points (correct).