### PR TITLE
Remove duplicate team-header data badges

### DIFF
--- a/index.html
+++ b/index.html
@@ -268,17 +268,11 @@
         <div class="text-right">
             <h1 class="text-3xl font-extrabold team-a" id="teamAName">Georgia</h1>
             <p class="text-sm text-zinc-400" id="teamARecord">12-1 · SEC</p>
-            <div class="mt-1 flex items-center justify-end gap-2">
-                <span class="dq-tooltip" id="teamAQuality"></span>
-            </div>
         </div>
         <div class="text-4xl font-black vs-badge">VS</div>
         <div class="text-left">
             <h1 class="text-3xl font-extrabold team-b" id="teamBName">Arizona State</h1>
             <p class="text-sm text-zinc-400" id="teamBRecord">5-7 · Big 12</p>
-            <div class="mt-1 flex items-center justify-start gap-2">
-                <span class="dq-tooltip" id="teamBQuality"></span>
-            </div>
         </div>
     </div>
 </div>
@@ -4333,8 +4327,12 @@ function updateHeader() {
     const aQuality = computeTeamQuality(af);
     const teamAQuality = document.getElementById('teamAQuality');
     const teamBQuality = document.getElementById('teamBQuality');
-    teamAQuality.innerHTML = `${qualityBadge(gQuality, 'Data')}<span class="dq-tooltip-content">${qualityTooltipHtml('Team data quality', gQuality)}</span>`;
-    teamBQuality.innerHTML = `${qualityBadge(aQuality, 'Data')}<span class="dq-tooltip-content">${qualityTooltipHtml('Team data quality', aQuality)}</span>`;
+    if (teamAQuality) {
+        teamAQuality.innerHTML = `${qualityBadge(gQuality, 'Data')}<span class="dq-tooltip-content">${qualityTooltipHtml('Team data quality', gQuality)}</span>`;
+    }
+    if (teamBQuality) {
+        teamBQuality.innerHTML = `${qualityBadge(aQuality, 'Data')}<span class="dq-tooltip-content">${qualityTooltipHtml('Team data quality', aQuality)}</span>`;
+    }
 }
 
 function switchFilter(id) {


### PR DESCRIPTION
## Summary
- removes the top-level Data % badges beside both team names in the matchup header
- keeps section-level/contextual data-quality badges unchanged
- adds null guards where header badge elements were previously injected to avoid runtime issues

## Why
The header badges duplicate data-quality info that is already shown in lower sections, so this cleans up the hero area without losing context.

## Testing
- loaded report page and confirmed team-name badges are gone
- confirmed section badges still render
- JS parse/syntax sanity check passes for inline scripts