### PR TITLE
Refine post-turnover chart and Special Teams cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -787,6 +787,29 @@ function maxSpecial(games, field) {
     return games.reduce((m,g) => Math.max(m, (g.special_teams && g.special_teams[field]) || 0), 0);
 }
 
+function buildMissedFgBreakdown(games) {
+    return games.map(g => {
+        const st = g.special_teams || {};
+        const attempts = Array.isArray(st.field_goal_attempts_detail) ? st.field_goal_attempts_detail : [];
+        const misses = attempts.filter(a => a && a.made === false);
+        if (!misses.length) return null;
+        const yardages = misses
+            .map(a => Number(a.yards))
+            .filter(y => Number.isFinite(y))
+            .sort((a, b) => a - b);
+        const value = yardages.length
+            ? yardages.map(y => `${y}y`).join(', ')
+            : `${misses.length} missed`;
+        return {
+            game_number: g.game_number,
+            opponent: g.opponent,
+            opponent_abbr: g.opponent_abbr,
+            date: g.date,
+            value,
+        };
+    }).filter(Boolean);
+}
+
 function normalizePlayerName(raw) {
     if (!raw || typeof raw !== 'string') return '';
     let name = raw.trim().replace(/\s+/g, ' ');
@@ -991,6 +1014,16 @@ function buildStatBadge(team, key) {
     if (!entry) return '';
     const meta = RANKING_META[key] || {};
     return renderStatBadge(entry.rank, entry.total, !!meta.reverse, entry.conference);
+}
+
+function buildFirstAvailableStatBadge(team, keys=[]) {
+    for (const key of keys) {
+        const entry = getRanking(team, key);
+        if (!entry || Array.isArray(entry)) continue;
+        const meta = RANKING_META[key] || {};
+        return renderStatBadge(entry.rank, entry.total, !!meta.reverse, entry.conference);
+    }
+    return '';
 }
 
 function formatRankingLabel(entry) {
@@ -2928,9 +2961,15 @@ function initFourthDownCharts() {
 }
 
 function renderSpecialTeams() {
-    const gf = filterGames(DATA.teams.georgia.games), af = filterGames(DATA.teams.asu.games);
+    const ga = DATA.teams.georgia, aa = DATA.teams.asu;
+    const gf = filterGames(ga.games), af = filterGames(aa.games);
     const gq = makeQuality(gf);
     const aq = makeQuality(af);
+    const rankingKeys = {
+        puntAvg: ['punt_avg', 'punting_avg', 'punting'],
+        puntsInside20: ['punts_inside_20', 'punt_inside_20', 'inside_20_punts'],
+        fgPct: ['field_goal_pct', 'fg_pct', 'field_goals_pct'],
+    };
     const buildStBreakdown = (games, getter) => games.map(g => {
         const st = g.special_teams || {};
         const value = Number(getter(st, g) || 0);
@@ -2947,14 +2986,12 @@ function renderSpecialTeams() {
     // Aggregate special teams data
     const gPunts = sumSpecial(gf, 'punts');
     const gPuntYds = sumSpecial(gf, 'punt_yards');
-    const gPuntNetYds = sumSpecial(gf, 'punt_net_yards');
     const gPuntAvg = gPunts ? (gPuntYds / gPunts).toFixed(1) : '0.0';
     const gPuntInside20 = sumSpecial(gf, 'punts_inside_20');
     const gPuntTouchbacks = sumSpecial(gf, 'punt_touchbacks');
     
     const aPunts = sumSpecial(af, 'punts');
     const aPuntYds = sumSpecial(af, 'punt_yards');
-    const aPuntNetYds = sumSpecial(af, 'punt_net_yards');
     const aPuntAvg = aPunts ? (aPuntYds / aPunts).toFixed(1) : '0.0';
     const aPuntInside20 = sumSpecial(af, 'punts_inside_20');
     const aPuntTouchbacks = sumSpecial(af, 'punt_touchbacks');
@@ -2970,6 +3007,8 @@ function renderSpecialTeams() {
     const aFgPct = aFgAtt ? (aFgMade / aFgAtt * 100).toFixed(1) : '0.0';
     const aFgMissed = aFgAtt - aFgMade;
     const aFgLong = maxSpecial(af, 'field_goal_long');
+    const gFgMissedBreakdown = buildMissedFgBreakdown(gf);
+    const aFgMissedBreakdown = buildMissedFgBreakdown(af);
     
     const gKo30 = sumSpecial(gf, 'kick_return_30_plus');
     const gPr20 = sumSpecial(gf, 'punt_return_20_plus');
@@ -2986,20 +3025,16 @@ function renderSpecialTeams() {
     // Punting section
     html += `<div class="glass rounded-xl p-4 mb-4"><div class="text-sm font-medium text-white mb-3">Punting</div>`;
     html += `<div class="grid grid-cols-2 gap-4">
-        <div class="grid grid-cols-3 gap-3">
+        <div class="grid grid-cols-2 gap-3">
             ${statCard('Punts', gPunts, '', 'team-a', gq(['special_teams.punts'], 'Punts'))}
-            ${statCard('Gross Yds', gPuntYds, '', 'team-a', gq(['special_teams.punt_yards'], 'Gross Yds'))}
-            ${statCard('Net Yds', gPuntNetYds, '', 'team-a', gq(['special_teams.punt_net_yards'], 'Net Yds'))}
-            ${statCard('Avg', gPuntAvg, '', 'team-a', gq(['special_teams.punts','special_teams.punt_yards'], 'Avg'))}
-            ${statCard('Inside 20', gPuntInside20, '', 'team-a', gq(['special_teams.punts_inside_20'], 'Inside 20'))}
+            ${statCard('Avg', gPuntAvg, '', 'team-a', gq(['special_teams.punts','special_teams.punt_yards'], 'Avg'), buildFirstAvailableStatBadge(ga, rankingKeys.puntAvg))}
+            ${statCard('Inside 20', gPuntInside20, '', 'team-a', gq(['special_teams.punts_inside_20'], 'Inside 20'), buildFirstAvailableStatBadge(ga, rankingKeys.puntsInside20))}
             ${statCard('Touchbacks', gPuntTouchbacks, '', 'team-a', gq(['special_teams.punt_touchbacks'], 'Touchbacks'))}
         </div>
-        <div class="grid grid-cols-3 gap-3">
+        <div class="grid grid-cols-2 gap-3">
             ${statCard('Punts', aPunts, '', 'team-b', aq(['special_teams.punts'], 'Punts'))}
-            ${statCard('Gross Yds', aPuntYds, '', 'team-b', aq(['special_teams.punt_yards'], 'Gross Yds'))}
-            ${statCard('Net Yds', aPuntNetYds, '', 'team-b', aq(['special_teams.punt_net_yards'], 'Net Yds'))}
-            ${statCard('Avg', aPuntAvg, '', 'team-b', aq(['special_teams.punts','special_teams.punt_yards'], 'Avg'))}
-            ${statCard('Inside 20', aPuntInside20, '', 'team-b', aq(['special_teams.punts_inside_20'], 'Inside 20'))}
+            ${statCard('Avg', aPuntAvg, '', 'team-b', aq(['special_teams.punts','special_teams.punt_yards'], 'Avg'), buildFirstAvailableStatBadge(aa, rankingKeys.puntAvg))}
+            ${statCard('Inside 20', aPuntInside20, '', 'team-b', aq(['special_teams.punts_inside_20'], 'Inside 20'), buildFirstAvailableStatBadge(aa, rankingKeys.puntsInside20))}
             ${statCard('Touchbacks', aPuntTouchbacks, '', 'team-b', aq(['special_teams.punt_touchbacks'], 'Touchbacks'))}
         </div>
     </div></div>`;
@@ -3010,15 +3045,15 @@ function renderSpecialTeams() {
         <div class="grid grid-cols-3 gap-3">
             ${statCard('Att', gFgAtt, '', 'team-a', gq(['special_teams.field_goals_attempts'], 'FG Att'))}
             ${statCard('Made', gFgMade, '', 'team-a', gq(['special_teams.field_goals_made'], 'FG Made'))}
-            ${statCard('Missed', gFgMissed, '', 'team-a', gq(['special_teams.field_goals_attempts','special_teams.field_goals_made'], 'FG Missed'))}
-            ${statCard('FG %', gFgPct + '%', '', 'team-a', gq(['special_teams.field_goals_made','special_teams.field_goals_attempts'], 'FG %'))}
+            ${statCardWithBreakdown('Missed', gFgMissed, '', 'team-a', gq(['special_teams.field_goals_attempts','special_teams.field_goals_made'], 'FG Missed'), gFgMissedBreakdown, 'No missed field goals recorded.')}
+            ${statCard('FG %', gFgPct + '%', '', 'team-a', gq(['special_teams.field_goals_made','special_teams.field_goals_attempts'], 'FG %'), buildFirstAvailableStatBadge(ga, rankingKeys.fgPct))}
             ${statCard('Longest', gFgLong || '—', '', 'team-a', gq(['special_teams.field_goal_long'], 'FG Long'))}
         </div>
         <div class="grid grid-cols-3 gap-3">
             ${statCard('Att', aFgAtt, '', 'team-b', aq(['special_teams.field_goals_attempts'], 'FG Att'))}
             ${statCard('Made', aFgMade, '', 'team-b', aq(['special_teams.field_goals_made'], 'FG Made'))}
-            ${statCard('Missed', aFgMissed, '', 'team-b', aq(['special_teams.field_goals_attempts','special_teams.field_goals_made'], 'FG Missed'))}
-            ${statCard('FG %', aFgPct + '%', '', 'team-b', aq(['special_teams.field_goals_made','special_teams.field_goals_attempts'], 'FG %'))}
+            ${statCardWithBreakdown('Missed', aFgMissed, '', 'team-b', aq(['special_teams.field_goals_attempts','special_teams.field_goals_made'], 'FG Missed'), aFgMissedBreakdown, 'No missed field goals recorded.')}
+            ${statCard('FG %', aFgPct + '%', '', 'team-b', aq(['special_teams.field_goals_made','special_teams.field_goals_attempts'], 'FG %'), buildFirstAvailableStatBadge(aa, rankingKeys.fgPct))}
             ${statCard('Longest', aFgLong || '—', '', 'team-b', aq(['special_teams.field_goal_long'], 'FG Long'))}
         </div>
     </div></div>`;
@@ -4155,17 +4190,21 @@ function printPostTurnoverSection() {
 }
 
 function printSpecialTeamsSection() {
-    const gf = filterGames(DATA.teams.georgia.games), af = filterGames(DATA.teams.asu.games);
+    const ga = DATA.teams.georgia, aa = DATA.teams.asu;
+    const gf = filterGames(ga.games), af = filterGames(aa.games);
     const gq = makeQuality(gf), aq = makeQuality(af);
+    const rankingKeys = {
+        puntAvg: ['punt_avg', 'punting_avg', 'punting'],
+        puntsInside20: ['punts_inside_20', 'punt_inside_20', 'inside_20_punts'],
+        fgPct: ['field_goal_pct', 'fg_pct', 'field_goals_pct'],
+    };
     const gPunts = sumSpecial(gf, 'punts');
     const gPuntYds = sumSpecial(gf, 'punt_yards');
-    const gPuntNetYds = sumSpecial(gf, 'punt_net_yards');
     const gPuntAvg = gPunts ? (gPuntYds / gPunts).toFixed(1) : '0.0';
     const gPuntInside20 = sumSpecial(gf, 'punts_inside_20');
     const gPuntTouchbacks = sumSpecial(gf, 'punt_touchbacks');
     const aPunts = sumSpecial(af, 'punts');
     const aPuntYds = sumSpecial(af, 'punt_yards');
-    const aPuntNetYds = sumSpecial(af, 'punt_net_yards');
     const aPuntAvg = aPunts ? (aPuntYds / aPunts).toFixed(1) : '0.0';
     const aPuntInside20 = sumSpecial(af, 'punts_inside_20');
     const aPuntTouchbacks = sumSpecial(af, 'punt_touchbacks');
@@ -4179,6 +4218,8 @@ function printSpecialTeamsSection() {
     const aFgPct = aFgAtt ? (aFgMade / aFgAtt * 100).toFixed(1) : '0.0';
     const aFgMissed = aFgAtt - aFgMade;
     const aFgLong = maxSpecial(af, 'field_goal_long');
+    const gFgMissedBreakdown = buildMissedFgBreakdown(gf);
+    const aFgMissedBreakdown = buildMissedFgBreakdown(af);
     const gKo30 = sumSpecial(gf, 'kick_return_30_plus');
     const gPr20 = sumSpecial(gf, 'punt_return_20_plus');
     const gStTds = sumSpecial(gf, 'special_teams_tds');
@@ -4190,20 +4231,16 @@ function printSpecialTeamsSection() {
 
     let html = `<div class="glass rounded-xl p-4 mb-4"><div class="text-sm font-medium text-white mb-3">Punting</div>
     <div class="grid grid-cols-2 gap-4">
-        <div class="grid grid-cols-3 gap-3">
+        <div class="grid grid-cols-2 gap-3">
             ${statCard('Punts', gPunts, '', 'team-a', gq(['special_teams.punts'], 'Punts'))}
-            ${statCard('Gross Yds', gPuntYds, '', 'team-a', gq(['special_teams.punt_yards'], 'Gross Yds'))}
-            ${statCard('Net Yds', gPuntNetYds, '', 'team-a', gq(['special_teams.punt_net_yards'], 'Net Yds'))}
-            ${statCard('Avg', gPuntAvg, '', 'team-a', gq(['special_teams.punts','special_teams.punt_yards'], 'Avg'))}
-            ${statCard('Inside 20', gPuntInside20, '', 'team-a', gq(['special_teams.punts_inside_20'], 'Inside 20'))}
+            ${statCard('Avg', gPuntAvg, '', 'team-a', gq(['special_teams.punts','special_teams.punt_yards'], 'Avg'), buildFirstAvailableStatBadge(ga, rankingKeys.puntAvg))}
+            ${statCard('Inside 20', gPuntInside20, '', 'team-a', gq(['special_teams.punts_inside_20'], 'Inside 20'), buildFirstAvailableStatBadge(ga, rankingKeys.puntsInside20))}
             ${statCard('Touchbacks', gPuntTouchbacks, '', 'team-a', gq(['special_teams.punt_touchbacks'], 'Touchbacks'))}
         </div>
-        <div class="grid grid-cols-3 gap-3">
+        <div class="grid grid-cols-2 gap-3">
             ${statCard('Punts', aPunts, '', 'team-b', aq(['special_teams.punts'], 'Punts'))}
-            ${statCard('Gross Yds', aPuntYds, '', 'team-b', aq(['special_teams.punt_yards'], 'Gross Yds'))}
-            ${statCard('Net Yds', aPuntNetYds, '', 'team-b', aq(['special_teams.punt_net_yards'], 'Net Yds'))}
-            ${statCard('Avg', aPuntAvg, '', 'team-b', aq(['special_teams.punts','special_teams.punt_yards'], 'Avg'))}
-            ${statCard('Inside 20', aPuntInside20, '', 'team-b', aq(['special_teams.punts_inside_20'], 'Inside 20'))}
+            ${statCard('Avg', aPuntAvg, '', 'team-b', aq(['special_teams.punts','special_teams.punt_yards'], 'Avg'), buildFirstAvailableStatBadge(aa, rankingKeys.puntAvg))}
+            ${statCard('Inside 20', aPuntInside20, '', 'team-b', aq(['special_teams.punts_inside_20'], 'Inside 20'), buildFirstAvailableStatBadge(aa, rankingKeys.puntsInside20))}
             ${statCard('Touchbacks', aPuntTouchbacks, '', 'team-b', aq(['special_teams.punt_touchbacks'], 'Touchbacks'))}
         </div>
     </div></div>`;
@@ -4213,15 +4250,15 @@ function printSpecialTeamsSection() {
         <div class="grid grid-cols-3 gap-3">
             ${statCard('Att', gFgAtt, '', 'team-a', gq(['special_teams.field_goals_attempts'], 'FG Att'))}
             ${statCard('Made', gFgMade, '', 'team-a', gq(['special_teams.field_goals_made'], 'FG Made'))}
-            ${statCard('Missed', gFgMissed, '', 'team-a')}
-            ${statCard('FG %', gFgPct + '%', '', 'team-a')}
+            ${statCardWithBreakdown('Missed', gFgMissed, '', 'team-a', gq(['special_teams.field_goals_attempts','special_teams.field_goals_made'], 'FG Missed'), gFgMissedBreakdown, 'No missed field goals recorded.')}
+            ${statCard('FG %', gFgPct + '%', '', 'team-a', gq(['special_teams.field_goals_made','special_teams.field_goals_attempts'], 'FG %'), buildFirstAvailableStatBadge(ga, rankingKeys.fgPct))}
             ${statCard('Longest', gFgLong || '\u2014', '', 'team-a', gq(['special_teams.field_goal_long'], 'FG Long'))}
         </div>
         <div class="grid grid-cols-3 gap-3">
             ${statCard('Att', aFgAtt, '', 'team-b', aq(['special_teams.field_goals_attempts'], 'FG Att'))}
             ${statCard('Made', aFgMade, '', 'team-b', aq(['special_teams.field_goals_made'], 'FG Made'))}
-            ${statCard('Missed', aFgMissed, '', 'team-b')}
-            ${statCard('FG %', aFgPct + '%', '', 'team-b')}
+            ${statCardWithBreakdown('Missed', aFgMissed, '', 'team-b', aq(['special_teams.field_goals_attempts','special_teams.field_goals_made'], 'FG Missed'), aFgMissedBreakdown, 'No missed field goals recorded.')}
+            ${statCard('FG %', aFgPct + '%', '', 'team-b', aq(['special_teams.field_goals_made','special_teams.field_goals_attempts'], 'FG %'), buildFirstAvailableStatBadge(aa, rankingKeys.fgPct))}
             ${statCard('Longest', aFgLong || '\u2014', '', 'team-b', aq(['special_teams.field_goal_long'], 'FG Long'))}
         </div>
     </div></div>`;


### PR DESCRIPTION
## Summary
- updates post-turnover per-game chart to show points off turnovers per game (no turnover-type split)
- fixes chart layout so legend and plot area do not overlap
- removes Gross Yds and Net Yds cards from Special Teams punting section
- adds conference badge hooks for Punt Avg, Inside 20, and FG % (when parser data is available)
- adds clickable missed-FG breakdown to show missed kick yardages by game
- keeps live UI and printable report behavior aligned

## Notes
- badge hooks are implemented with safe fallback and only render when ranking keys are present in team.cfbstats.rankings
- parser-side requirements for those ranking keys are tracked in:
  - https://github.com/victorres11/pbp-parser/issues/77

## Validation
- inline script syntax check passes
- branch is pushed and up to date