### PR TITLE
feat: add demo runbook and one-command brief generator

### DIFF
--- a/docs/demo-runbook.md
+++ b/docs/demo-runbook.md
@@ -27,5 +27,6 @@ The runner writes:
 
 ## Source Policy
 
-- StatBroadcast-derived data is the preferred source path.
-- Legacy PDF parsing code is retained for fallback/debug only and should remain disabled by default.
+- StatBroadcast-derived data is the preferred **input data source**.
+- Legacy PDF **input parsing** is retained for fallback/debug only and should remain disabled by default.
+- PDF **output/export of generated briefs** is still supported and is not being removed.

--- a/scripts/game_prep_brief/demo_runner.py
+++ b/scripts/game_prep_brief/demo_runner.py
@@ -92,7 +92,8 @@ def _write_summary(cfg: dict, md_path: Path, html_path: Path, output_dir: Path) 
                 "## Known Gaps (Current)",
                 "- Situational receiver targets (3rd down / red zone) require PFF integration",
                 "- Some opponent-relative schedule rows may use fallback baseline when opponent season profile is unavailable",
-                "- StatBroadcast-only pipeline is the intended source path moving forward",
+                "- StatBroadcast is the intended input data source moving forward",
+                "- PDF output/export of generated briefs remains supported",
                 "",
             ]
         )


### PR DESCRIPTION
Adds a reproducible demo flow for issue #141 demo readiness.

## What this adds
- `scripts/game_prep_brief/demo_runner.py`: one-command generator for demo brief packages
- `docs/demo-runbook.md`: runbook with commands, outputs, and source policy notes

## Why
- Standardizes demo artifact generation (HTML + markdown + checklist) for stakeholder review
- Reduces manual steps and mismatch risk when preparing weekly demos

## Validation
- Ran: `python3 scripts/game_prep_brief/demo_runner.py --matchup oregon-usc-2025 --output-dir /tmp/pbp-demo-check`
- Outputs generated:
  - `/tmp/pbp-demo-check/oregon_vs_usc_2025_v2.md`
  - `/tmp/pbp-demo-check/oregon_vs_usc_2025_v2.html`
  - `/tmp/pbp-demo-check/DEMO_SUMMARY.md`
