### PR TITLE
Fix game brief PDF readability and remove redundant metrics block

### DIFF
--- a/scripts/game_prep_brief/renderers/html.py
+++ b/scripts/game_prep_brief/renderers/html.py
@@ -114,6 +114,9 @@ def render(sections: list[dict], team1: dict, team2: dict, week: int | None, sea
       grid-template-columns: repeat(2, minmax(0, 1fr));
       gap: 16px;
     }}
+    .section-grid--single {{
+      grid-template-columns: 1fr;
+    }}
     .team-card {{
       border: 1px solid var(--border);
       border-radius: 10px;
@@ -131,6 +134,22 @@ def render(sections: list[dict], team1: dict, team2: dict, week: int | None, sea
     .rankings-table th {{ text-transform: uppercase; font-size: 11px; color: #64748b; text-align: left; }}
 
     .metric-compare {{ margin: 8px 0 12px; }}
+    .schedule-table-wrap {{ overflow-x: auto; }}
+    .schedule-table th, .schedule-table td {{
+      padding: 4px 6px;
+      vertical-align: top;
+      white-space: nowrap;
+      border-bottom: 1px solid var(--border);
+      font-size: 11px;
+    }}
+    .schedule-table th {{
+      color: #475569;
+      font-weight: 700;
+    }}
+    .schedule-table td:nth-child(2), .schedule-table th:nth-child(2) {{
+      white-space: normal;
+      min-width: 120px;
+    }}
 
     @media print {{
       body {{ background: white; padding: 8px; }}
@@ -147,10 +166,12 @@ def render(sections: list[dict], team1: dict, team2: dict, week: int | None, sea
         padding-bottom: 4px;
       }}
       .section-grid {{ gap: 10px; }}
+      .section-grid--single {{ grid-template-columns: 1fr; }}
       .team-card {{
         break-inside: avoid-page;
         page-break-inside: avoid;
       }}
+      .schedule-table-wrap {{ overflow: visible; }}
       .header {{ box-shadow: none; }}
       @page {{ margin: 1cm; }}
     }}

--- a/scripts/game_prep_brief/sections/rankings.py
+++ b/scripts/game_prep_brief/sections/rankings.py
@@ -107,25 +107,6 @@ def _top_bottom_md(team: dict) -> str:
     return "\n".join(lines)
 
 
-def _metric_text(team1: dict, team2: dict) -> str:
-    rankings1 = (team1.get("pbp_entry") or {}).get("cfbstats", {}).get("rankings", {}).get("all", {})
-    rankings2 = (team2.get("pbp_entry") or {}).get("cfbstats", {}).get("rankings", {}).get("all", {})
-
-    def val(rankings: dict, key: str) -> float:
-        v = rankings.get(key, {}).get("value")
-        try:
-            return float(v)
-        except (TypeError, ValueError):
-            return 0.0
-
-    lines = []
-    for key in ["scoring_offense", "scoring_defense", "total_offense", "total_defense"]:
-        v1 = val(rankings1, key)
-        v2 = val(rankings2, key)
-        lines.append(f"<p>{LABELS.get(key, key)}: {team1.get('display_name', 'Team 1')} {v1:.1f} | {team2.get('display_name', 'Team 2')} {v2:.1f}</p>")
-    return "".join(f"<div class=\"metric-compare\">{l}</div>" for l in lines)
-
-
 def build(team1: dict, team2: dict) -> dict:
     """Full 18-category rankings section with all/conf/nonconf splits."""
     all_1 = (team1.get("pbp_entry") or {}).get("cfbstats", {}).get("rankings", {}).get("all", {})
@@ -148,7 +129,6 @@ def build(team1: dict, team2: dict) -> dict:
     )
     html_content = (
         f"{delta_html}"
-        f"{_metric_text(team1, team2)}"
         f"{_table_html(team1, team2, 'all')}"
         f"{_table_html(team1, team2, 'conf')}"
         f"{_table_html(team1, team2, 'nonconf')}"

--- a/scripts/game_prep_brief/sections/schedule.py
+++ b/scripts/game_prep_brief/sections/schedule.py
@@ -201,7 +201,8 @@ def _team_html(team: dict) -> str:
       </div>
       <div class="block">
         <h4>Schedule</h4>
-        <table style="width:100%; border-collapse:collapse; font-size:0.9em;">
+        <div class="schedule-table-wrap">
+        <table class="schedule-table" style="width:100%; border-collapse:collapse; font-size:0.9em;">
           <thead>
             <tr>
               <th style="text-align:left;">Wk</th>
@@ -218,6 +219,7 @@ def _team_html(team: dict) -> str:
           </thead>
           <tbody>{rows}</tbody>
         </table>
+        </div>
       </div>
     </div>
     """
@@ -277,7 +279,7 @@ def build(team1: dict, team2: dict) -> dict:
 
     html_content = f"""
     {delta_html}
-    <div class="section-grid">
+    <div class="section-grid section-grid--single">
       {_team_html(team1)}
       {_team_html(team2)}
     </div>


### PR DESCRIPTION
- removes the Scoring/Total offense-defense metric text block from Rankings\n- stacks schedule team tables vertically for print/PDF readability\n- adds schedule table styling for cleaner print output