### PR TITLE
Keep cached enrichment values during API outages

### DIFF
--- a/scripts/game_prep_brief/__main__.py
+++ b/scripts/game_prep_brief/__main__.py
@@ -14,6 +14,7 @@ from .loaders import (
     OUTPUT_DIR,
     slugify,
     build_enrichment_payload,
+    merge_enrichment_payload,
     load_enrichment_file,
     write_enrichment_file,
     gather_team_data,
@@ -93,7 +94,7 @@ def main():
     if args.refresh_enrichment or not enrichment_by_slug:
         refreshed = build_enrichment_payload(team_specs)
         if refreshed:
-            enrichment_by_slug.update(refreshed)
+            enrichment_by_slug = merge_enrichment_payload(enrichment_by_slug, refreshed)
             write_enrichment_file(enrichment_file, enrichment_by_slug)
             print(f"[ok] Enrichment → {enrichment_file}", file=sys.stderr)
         else:

--- a/scripts/game_prep_brief/loaders.py
+++ b/scripts/game_prep_brief/loaders.py
@@ -1033,6 +1033,27 @@ def write_enrichment_file(path: Path, payload: dict) -> None:
         json.dump(payload, f, indent=2, sort_keys=True)
 
 
+def merge_enrichment_payload(existing: dict, refreshed: dict) -> dict:
+    """Preserve prior non-empty enrichment values when live refresh is unavailable."""
+    merged: dict = dict(existing or {})
+    for slug, incoming in (refreshed or {}).items():
+        if not isinstance(incoming, dict):
+            continue
+        prior = merged.get(slug) if isinstance(merged.get(slug), dict) else {}
+        out = dict(prior)
+        for key, value in incoming.items():
+            if key in ENRICHMENT_KEYS and value in ("N/A", None, ""):
+                prior_value = prior.get(key)
+                if prior_value not in ("N/A", None, ""):
+                    out[key] = prior_value
+                    continue
+            out[key] = value
+        has_signal = any(out.get(k) not in ("N/A", None, "") for k in ENRICHMENT_KEYS)
+        out["_status"] = "ok" if has_signal else "unavailable"
+        merged[slug] = out
+    return merged
+
+
 def compute_last_n_stats(games: list[dict], n: int = 3) -> dict:
     sorted_games = sorted(games, key=lambda g: g.get("game_number", 0), reverse=True)
     last_games = sorted_games[:n]


### PR DESCRIPTION
## Summary
- add merge_enrichment_payload helper for enrichment refresh
- when refreshed value is N/A/empty, keep existing non-empty cached value for enrichment keys
- prevent transient yr-data-api outages from erasing previously good blitz/PFF values

## Validation
- merge behavior check:
  - existing blitz values + refreshed N/A preserves existing values
- regenerated brief with --refresh-enrichment and confirmed output generation succeeds:
  - outputs/game_prep_brief/washington_vs_ohio-state_2025_v2.md
  - outputs/game_prep_brief/washington_vs_ohio-state_2025_v2.html