### PR TITLE
feat: add data source indicators to game prep brief

### DIFF
--- a/scripts/game_prep_brief/renderers/html.py
+++ b/scripts/game_prep_brief/renderers/html.py
@@ -276,6 +276,9 @@ def render(sections: list[dict], team1: dict, team2: dict, week: int | None, sea
 
     .metric-compare {{ margin: 8px 0 12px; }}
 
+    sup.src {{ font-size: 9px; color: #94a3b8; font-weight: 400; vertical-align: super; margin-left: 2px; }}
+    .source-legend {{ font-size: 11px; color: #94a3b8; margin-top: 8px; }}
+
     .page-break {{ page-break-before: always; }}
     .page-break:first-child {{ page-break-before: auto; }}
 
@@ -296,6 +299,7 @@ def render(sections: list[dict], team1: dict, team2: dict, week: int | None, sea
       <h1>Game Prep Brief v2</h1>
       <div class="subtitle">{week_str}{season} Season · {team1['display_name']} vs {team2['display_name']} · Generated {now}</div>
       {"<div class='warning'><strong>Data Notice:</strong> " + warning_text + "</div>" if warning_text else ""}
+      <div class="source-legend"><sup class="src">pbp</sup> Play-by-Play Parser · <sup class="src">cfb</sup> CFBStats · <sup class="src">pff</sup> PFF/API</div>
     </div>
   </header>
 

--- a/scripts/game_prep_brief/sections/_sources.py
+++ b/scripts/game_prep_brief/sections/_sources.py
@@ -1,0 +1,12 @@
+"""Data source indicator tags for game prep brief HTML output."""
+from __future__ import annotations
+
+
+def _src(label: str) -> str:
+    return f'<sup class="src">{label}</sup>'
+
+
+SRC_PBP = _src("pbp")
+SRC_CFB = _src("cfb")
+SRC_PFF = _src("pff")
+SRC_API = _src("api")

--- a/scripts/game_prep_brief/sections/explosives.py
+++ b/scripts/game_prep_brief/sections/explosives.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import re
 
 from ._names import format_player_name
+from ._sources import SRC_PBP, SRC_CFB
 
 
 def _abbr_set(value: object) -> set[str]:
@@ -375,9 +376,9 @@ def _team_html(team: dict) -> str:
       <div class="block">
         <h4>Last {actual_n} Trending</h4>
         <ul>
-          <li>Explosives/Game: {l3_epg:.1f} (Season: {season_epg:.1f}){epg_arrow}</li>
-          <li>Pass/Game: {l3_ppg:.1f} / Rush/Game: {l3_rpg:.1f}</li>
-          <li>Non-Explosive Avg (Run/Pass): {ne_last_n['rush_avg']:.2f} / {ne_last_n['pass_avg']:.2f}</li>
+          <li>Explosives/Game: {l3_epg:.1f} (Season: {season_epg:.1f}){epg_arrow}{SRC_PBP}</li>
+          <li>Pass/Game: {l3_ppg:.1f} / Rush/Game: {l3_rpg:.1f}{SRC_PBP}</li>
+          <li>Non-Explosive Avg (Run/Pass): {ne_last_n['rush_avg']:.2f} / {ne_last_n['pass_avg']:.2f}{SRC_PBP}</li>
         </ul>
       </div>
         """
@@ -388,11 +389,11 @@ def _team_html(team: dict) -> str:
       <div class="block">
         <h4>Totals</h4>
         <ul>
-          <li>CFBStats Explosives (20+): {cfb_expl_raw if cfb_expl_raw not in (None, '') else 'N/A'}{f' (#{cfb_expl_rank})' if cfb_expl_rank not in (None, '') else ''}</li>
-          <li>PBP Explosives: {totals['explosives']} (Pass {totals['explosive_passes']}, Rush {totals['explosive_rushes']})</li>
+          <li>CFBStats Explosives (20+): {cfb_expl_raw if cfb_expl_raw not in (None, '') else 'N/A'}{f' (#{cfb_expl_rank})' if cfb_expl_rank not in (None, '') else ''}{SRC_CFB}</li>
+          <li>PBP Explosives: {totals['explosives']} (Pass {totals['explosive_passes']}, Rush {totals['explosive_rushes']}){SRC_PBP}</li>
           <li>Delta (PBP-CFBStats): {delta_text} · {delta_status}</li>
-          <li>15-19y Rushes (PBP only): {defs['rush_15_19']} (expected definition delta)</li>
-          <li>PBP 20+ (pass/rush): {defs['pbp_20_total']} (Pass {defs['pass_20_plus']}, Rush {defs['rush_20_plus']})</li>
+          <li>15-19y Rushes (PBP only): {defs['rush_15_19']} (expected definition delta){SRC_PBP}</li>
+          <li>PBP 20+ (pass/rush): {defs['pbp_20_total']} (Pass {defs['pass_20_plus']}, Rush {defs['rush_20_plus']}){SRC_PBP}</li>
           <li>Delta using PBP 20+ vs CFBStats: {threshold_delta_text} (residual {residual_text})</li>
         </ul>
       </div>
@@ -404,8 +405,8 @@ def _team_html(team: dict) -> str:
       <div class="block">
         <h4>Without Explosives</h4>
         <ul>
-          <li>Run Avg (&lt;15y): {ne_season['rush_avg']:.2f} ({ne_season['rush_att']} att)</li>
-          <li>Pass Avg (&lt;20y): {ne_season['pass_avg']:.2f} ({ne_season['pass_att']} att)</li>
+          <li>Run Avg (&lt;15y): {ne_season['rush_avg']:.2f} ({ne_season['rush_att']} att){SRC_PBP}</li>
+          <li>Pass Avg (&lt;20y): {ne_season['pass_avg']:.2f} ({ne_season['pass_att']} att){SRC_PBP}</li>
         </ul>
       </div>
       <div class="block">

--- a/scripts/game_prep_brief/sections/matchups.py
+++ b/scripts/game_prep_brief/sections/matchups.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from ._sources import SRC_CFB
+
 
 MATCHUP_KEYS = [
     ("scoring_offense", "scoring_defense", "Scoring"),
@@ -110,8 +112,8 @@ def build(team1: dict, team2: dict) -> dict:
         table_rows += (
             f"<tr>"
             f"<td>{r['label']}</td>"
-            f"<td>{r['offense']} OFF #{r['off_rank']}</td>"
-            f"<td>{r['defense']} DEF #{r['def_rank']}</td>"
+            f"<td>{r['offense']} OFF #{r['off_rank']}{SRC_CFB}</td>"
+            f"<td>{r['defense']} DEF #{r['def_rank']}{SRC_CFB}</td>"
             f"<td>{tag}</td>"
             f"</tr>"
         )

--- a/scripts/game_prep_brief/sections/middle8.py
+++ b/scripts/game_prep_brief/sections/middle8.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import re
 
 from ._names import format_player_name
+from ._sources import SRC_PBP
 
 _NAME_COMMA_RE = r"([A-Z][A-Za-z]+(?:\s+(?:Jr|Jr\.|Sr|Sr\.|II|III|IV|V|[A-Z]+))?,\s*[A-Za-z]+)"
 
@@ -341,8 +342,8 @@ def _team_html(team: dict) -> str:
       <div class="block">
         <h4>Season Totals</h4>
         <ul>
-          <li>Points For / Against: {pts_for} / {pts_against}</li>
-          <li>Margin: {margin}</li>
+          <li>Points For / Against: {pts_for} / {pts_against}{SRC_PBP}</li>
+          <li>Margin: {margin}{SRC_PBP}</li>
         </ul>
       </div>
       {last_n_html}

--- a/scripts/game_prep_brief/sections/overview.py
+++ b/scripts/game_prep_brief/sections/overview.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from datetime import datetime
 
+from ._sources import SRC_PBP
+
 
 def _should_show_last_n(team: dict) -> bool:
     last_n = team.get("last_n", {})
@@ -39,8 +41,8 @@ def _season_summary(team: dict) -> list[str]:
             f"L{actual_n}: {l_ppg_str} for / {l_opp_ppg_str} against"
         )
     return [
-        f"Record: {record_line}",
-        ppg_line,
+        f"Record: {record_line}{SRC_PBP}",
+        f"{ppg_line}{SRC_PBP}",
     ]
 
 
@@ -54,7 +56,7 @@ def _team_html(team: dict) -> str:
     recent = _recent_results(team)
 
     summary_html = "".join(f"<li>{l}</li>" for l in summary)
-    recent_html = "".join(f"<li>{r}</li>" for r in recent) if recent else "<li>N/A</li>"
+    recent_html = "".join(f"<li>{r}{SRC_PBP}</li>" for r in recent) if recent else "<li>N/A</li>"
 
     return f"""
     <div class="team-card">

--- a/scripts/game_prep_brief/sections/penalties.py
+++ b/scripts/game_prep_brief/sections/penalties.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import re
 from collections import Counter, defaultdict
 
+from ._sources import SRC_PBP, SRC_CFB
+
 PROCEDURAL_TERMS = (
     "false start",
     "offside",
@@ -518,15 +520,15 @@ def _team_html(team: dict) -> str:
       <div class=\"block\">
         <h4>Totals</h4>
         <ul>
-          <li>Penalties/Game: {f"{pen_per_game:.1f}" if isinstance(pen_per_game, (int, float)) else 'N/A'} | Yards/Game: {f"{yds_per_game:.1f}" if isinstance(yds_per_game, (int, float)) else 'N/A'}</li>
-          <li>Penalties: {agg['total']} for {agg['yards']} yards</li>
-          <li>Offense: {offense['count']} / {offense['yards']} yds</li>
-          <li>Defense: {defense['count']} / {defense['yards']} yds</li>
-          <li>Procedural: {f"{procedural['count']} / {procedural['yards']} yds" if show_group else 'N/A'}</li>
-          <li>Live-ball: {f"{live_ball['count']} / {live_ball['yards']} yds" if show_group else 'N/A'}</li>
-          <li>PI Drawn: {agg['pi_drawn'] if show_pi else 'N/A'} | PI Allowed: {agg['pi_allowed'] if show_pi else 'N/A'}</li>
-          <li>Offensive Holding: {f"{agg['off_holding']} / {agg['off_holding_yards']} yds" if show_holding else 'N/A'} | Defensive Holding: {f"{agg['def_holding']} / {agg['def_holding_yards']} yds" if show_holding else 'N/A'}</li>
-          <li>CFBStats Rank: {_penalties_rank(team)}</li>
+          <li>Penalties/Game: {f"{pen_per_game:.1f}" if isinstance(pen_per_game, (int, float)) else 'N/A'} | Yards/Game: {f"{yds_per_game:.1f}" if isinstance(yds_per_game, (int, float)) else 'N/A'}{SRC_PBP}</li>
+          <li>Penalties: {agg['total']} for {agg['yards']} yards{SRC_PBP}</li>
+          <li>Offense: {offense['count']} / {offense['yards']} yds{SRC_PBP}</li>
+          <li>Defense: {defense['count']} / {defense['yards']} yds{SRC_PBP}</li>
+          <li>Procedural: {f"{procedural['count']} / {procedural['yards']} yds" if show_group else 'N/A'}{SRC_PBP}</li>
+          <li>Live-ball: {f"{live_ball['count']} / {live_ball['yards']} yds" if show_group else 'N/A'}{SRC_PBP}</li>
+          <li>PI Drawn: {agg['pi_drawn'] if show_pi else 'N/A'} | PI Allowed: {agg['pi_allowed'] if show_pi else 'N/A'}{SRC_PBP}</li>
+          <li>Offensive Holding: {f"{agg['off_holding']} / {agg['off_holding_yards']} yds" if show_holding else 'N/A'} | Defensive Holding: {f"{agg['def_holding']} / {agg['def_holding_yards']} yds" if show_holding else 'N/A'}{SRC_PBP}</li>
+          <li>CFBStats Rank: {_penalties_rank(team)}{SRC_CFB}</li>
         </ul>
       </div>
       {last_n_html}

--- a/scripts/game_prep_brief/sections/rankings.py
+++ b/scripts/game_prep_brief/sections/rankings.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 import re
 
+from ._sources import SRC_CFB
+
 CATEGORIES = [
     "scoring_offense",
     "scoring_defense",
@@ -72,7 +74,7 @@ def _table_html(team1: dict, team2: dict, scope: str) -> str:
     rows = []
     for key in CATEGORIES:
         rows.append(
-            f"<tr><td>{LABELS.get(key, key)}</td><td>{_fmt(_rank(r1, key))}</td><td>{_fmt(_rank(r2, key))}</td></tr>"
+            f"<tr><td>{LABELS.get(key, key)}</td><td>{_fmt(_rank(r1, key))}{SRC_CFB}</td><td>{_fmt(_rank(r2, key))}{SRC_CFB}</td></tr>"
         )
     rows_html = "".join(rows)
     return f"""

--- a/scripts/game_prep_brief/sections/schedule.py
+++ b/scripts/game_prep_brief/sections/schedule.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from ._sources import SRC_PBP
+
 
 def _safe_float(value: object) -> float | None:
     try:
@@ -229,6 +231,7 @@ def build(team1: dict, team2: dict) -> dict:
       {_team_table_html(team1)}
       {_team_table_html(team2)}
     </div>
+    <div class="section-note">All schedule data sourced from play-by-play parser.{SRC_PBP}</div>
     """
     md_content = "\n\n".join([
         "*Schedule Snapshot*",

--- a/scripts/game_prep_brief/sections/situational.py
+++ b/scripts/game_prep_brief/sections/situational.py
@@ -3,6 +3,7 @@ import re
 from collections import defaultdict
 
 from ._names import format_player_name
+from ._sources import SRC_PBP, SRC_CFB, SRC_PFF
 
 
 def _abbr_set(value: object) -> set[str]:
@@ -310,14 +311,15 @@ def _team_html(team: dict) -> str:
             last_n_line = f"<li>{l3_display}</li>"
 
     trenches_unavailable = all(_is_na(v) for v in (sacks_allowed_pg, sacks_pg, tfl_pg, tfl_allowed, mt_pg, fmt_pg))
+    _trench_src = SRC_PFF if not _is_na(stats.get("pff_sacks_pg")) else SRC_PBP
     trenches_html = (
         "<li>XML source currently does not include blitz/missed-tackle charting.</li>"
         if trenches_unavailable
         else (
-            f"<li>Sacks Allowed/G: {_num_display(sacks_allowed_pg)}</li>"
-            f"<li>Sacks (Def)/G: {_num_display(sacks_pg)} | TFL/G: {_num_display(tfl_pg)}</li>"
-            f"<li>TFL Allowed (season): {tfl_allowed}</li>"
-            f"<li>Missed Tackles/G: {_num_display(mt_pg)} | FMT/G: {_num_display(fmt_pg)}</li>"
+            f"<li>Sacks Allowed/G: {_num_display(sacks_allowed_pg)}{_trench_src}</li>"
+            f"<li>Sacks (Def)/G: {_num_display(sacks_pg)} | TFL/G: {_num_display(tfl_pg)}{_trench_src}</li>"
+            f"<li>TFL Allowed (season): {tfl_allowed}{SRC_CFB}</li>"
+            f"<li>Missed Tackles/G: {_num_display(mt_pg)} | FMT/G: {_num_display(fmt_pg)}{SRC_PFF}</li>"
         )
     )
 
@@ -327,32 +329,32 @@ def _team_html(team: dict) -> str:
       <div class="block">
         <h4>3rd Down</h4>
         <ul>
-          <li>CFBStats: {third_down}</li>
-          <li>Conversions / Attempts (PBP): {third_conv} / {third_att} ({f"{third_pct_derived}%" if isinstance(third_pct_derived, (int, float)) else "N/A"})</li>
+          <li>CFBStats: {third_down}{SRC_CFB}</li>
+          <li>Conversions / Attempts (PBP): {third_conv} / {third_att} ({f"{third_pct_derived}%" if isinstance(third_pct_derived, (int, float)) else "N/A"}){SRC_PBP}</li>
           {third_down_l3_line}
         </ul>
       </div>
       <div class="block">
         <h4>Blitz Rate</h4>
         <ul>
-          <li>Season: {_display_or_unavailable(blitz_pct, '%')}</li>
-          <li>Last 3: {_display_or_unavailable(blitz_pct_last3, '%')}</li>
+          <li>Season: {_display_or_unavailable(blitz_pct, '%')}{SRC_PFF}</li>
+          <li>Last 3: {_display_or_unavailable(blitz_pct_last3, '%')}{SRC_PFF}</li>
         </ul>
       </div>
       <div class="block">
         <h4>Negative Plays</h4>
         <ul>
-          <li>Offense (Season / L3): {_num_display(neg_off, '/gm')} / {_num_display(neg_off_l3, '/gm')}</li>
-          <li>Defense Forced (Season / L3): {_num_display(neg_def, '/gm')} / {_num_display(neg_def_l3, '/gm')}</li>
+          <li>Offense (Season / L3): {_num_display(neg_off, '/gm')} / {_num_display(neg_off_l3, '/gm')}{SRC_PBP}</li>
+          <li>Defense Forced (Season / L3): {_num_display(neg_def, '/gm')} / {_num_display(neg_def_l3, '/gm')}{SRC_PBP}</li>
         </ul>
       </div>
       <div class="block">
         <h4>Tempo</h4>
         <ul>
-          <li>Avg Time to Snap: {_display_or_unavailable(stats.get('pff_avg_play_clock'), 's')}</li>
-          <li>Hurry-Up Rate (≤10s): {_display_or_unavailable(stats.get('pff_hurry_up_pct'))}</li>
-          <li>Plays/Game Offense (Season / L3): {_num_display(off_plays_pg)} / {_num_display(off_plays_l3)}</li>
-          <li>Plays/Game Defense Allowed (Season / L3): {_num_display(def_plays_pg)} / {_num_display(def_plays_l3)}</li>
+          <li>Avg Time to Snap: {_display_or_unavailable(stats.get('pff_avg_play_clock'), 's')}{SRC_PFF}</li>
+          <li>Hurry-Up Rate (≤10s): {_display_or_unavailable(stats.get('pff_hurry_up_pct'))}{SRC_PFF}</li>
+          <li>Plays/Game Offense (Season / L3): {_num_display(off_plays_pg)} / {_num_display(off_plays_l3)}{SRC_PBP}</li>
+          <li>Plays/Game Defense Allowed (Season / L3): {_num_display(def_plays_pg)} / {_num_display(def_plays_l3)}{SRC_PBP}</li>
         </ul>
       </div>
       <div class="block">
@@ -372,10 +374,10 @@ def _team_html(team: dict) -> str:
       <div class="block">
         <h4>4th Down</h4>
         <ul>
-          <li>Attempts / Conversions: {attempts if attempts is not None else 'N/A'} / {conversions if conversions is not None else 'N/A'}</li>
-          <li>Conversion %: {f"{pct}%" if isinstance(pct, (int, float)) else "N/A"}</li>
+          <li>Attempts / Conversions: {attempts if attempts is not None else 'N/A'} / {conversions if conversions is not None else 'N/A'}{SRC_PBP}</li>
+          <li>Conversion %: {f"{pct}%" if isinstance(pct, (int, float)) else "N/A"}{SRC_PBP}</li>
           {last_n_line}
-          <li>CFBStats: {_fourth_down_rank(team)}</li>
+          <li>CFBStats: {_fourth_down_rank(team)}{SRC_CFB}</li>
         </ul>
       </div>
       <div class="block">

--- a/scripts/game_prep_brief/sections/special_teams.py
+++ b/scripts/game_prep_brief/sections/special_teams.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from ._sources import SRC_PBP
+
 
 def _games(team: dict) -> list[dict]:
     pbp = team.get("pbp_entry") or {}
@@ -272,40 +274,40 @@ def _team_html(team: dict) -> str:
       <div class="block">
         <h4>Field Goals</h4>
         <ul>
-          <li>Made/Att: {stats['fg_made']} / {stats['fg_att']} ({_fmt_num(stats['fg_pct'], '%')})</li>
-          <li>Long: {stats['fg_long']}</li>
+          <li>Made/Att: {stats['fg_made']} / {stats['fg_att']} ({_fmt_num(stats['fg_pct'], '%')}){SRC_PBP}</li>
+          <li>Long: {stats['fg_long']}{SRC_PBP}</li>
         </ul>
       </div>
       <div class="block">
         <h4>Punting</h4>
         <ul>
-          <li>Avg / Net: {_fmt_num(stats['punt_avg'])} / {_fmt_num(stats['punt_net_avg'])}</li>
-          <li>Long: {stats['punt_long']}</li>
-          <li>Inside 20: {stats['punts_inside_20']} · TB: {stats['punt_touchbacks']}</li>
+          <li>Avg / Net: {_fmt_num(stats['punt_avg'])} / {_fmt_num(stats['punt_net_avg'])}{SRC_PBP}</li>
+          <li>Long: {stats['punt_long']}{SRC_PBP}</li>
+          <li>Inside 20: {stats['punts_inside_20']} · TB: {stats['punt_touchbacks']}{SRC_PBP}</li>
         </ul>
       </div>
       <div class="block">
         <h4>Returns</h4>
         <ul>
-          <li>Punt Return Avg/Long: {_fmt_num(stats['punt_return_avg'])} / {stats['punt_return_long']} (20+ {stats['punt_20_plus']})</li>
-          <li>Punt Return Allowed Avg/Long: {_fmt_num(stats['punt_return_allowed_avg'])} / {stats['punt_return_long_allowed']} (20+ {stats['punt_20_plus_allowed']})</li>
-          <li>KO Return Avg/Long: {_fmt_num(stats['kick_return_avg'])} / {stats['kick_return_long']} (30+ {stats['kick_30_plus']})</li>
+          <li>Punt Return Avg/Long: {_fmt_num(stats['punt_return_avg'])} / {stats['punt_return_long']} (20+ {stats['punt_20_plus']}){SRC_PBP}</li>
+          <li>Punt Return Allowed Avg/Long: {_fmt_num(stats['punt_return_allowed_avg'])} / {stats['punt_return_long_allowed']} (20+ {stats['punt_20_plus_allowed']}){SRC_PBP}</li>
+          <li>KO Return Avg/Long: {_fmt_num(stats['kick_return_avg'])} / {stats['kick_return_long']} (30+ {stats['kick_30_plus']}){SRC_PBP}</li>
         </ul>
       </div>
       <div class="block">
         <h4>Impact Plays</h4>
         <ul>
-          <li>ST TDs: {_fmt_int(stats['special_teams_tds'])}</li>
-          <li>FG Blocks: {_fmt_int(stats['fg_blocks'])} · Punt Blocks: {_fmt_int(stats['punt_blocks'])}</li>
-          <li>Onside: {_fmt_int(stats['onside_recovered'])} / {_fmt_int(stats['onside_attempts'])}</li>
+          <li>ST TDs: {_fmt_int(stats['special_teams_tds'])}{SRC_PBP}</li>
+          <li>FG Blocks: {_fmt_int(stats['fg_blocks'])} · Punt Blocks: {_fmt_int(stats['punt_blocks'])}{SRC_PBP}</li>
+          <li>Onside: {_fmt_int(stats['onside_recovered'])} / {_fmt_int(stats['onside_attempts'])}{SRC_PBP}</li>
         </ul>
       </div>
       <div class="block">
         <h4>Two-Point Conversions</h4>
         <ul>
-          <li>Offense: {_fmt_two_pt(stats['two_pt_conv'], stats['two_pt_att'])}</li>
-          <li>Defense Allowed: {_fmt_two_pt(stats['two_pt_allowed_conv'], stats['two_pt_allowed_att'])}</li>
-          <li>Last 3 O/D: {_fmt_two_pt(stats['l3_two_pt_conv'], stats['l3_two_pt_att'])} · {_fmt_two_pt(stats['l3_two_pt_allowed_conv'], stats['l3_two_pt_allowed_att'])}</li>
+          <li>Offense: {_fmt_two_pt(stats['two_pt_conv'], stats['two_pt_att'])}{SRC_PBP}</li>
+          <li>Defense Allowed: {_fmt_two_pt(stats['two_pt_allowed_conv'], stats['two_pt_allowed_att'])}{SRC_PBP}</li>
+          <li>Last 3 O/D: {_fmt_two_pt(stats['l3_two_pt_conv'], stats['l3_two_pt_att'])} · {_fmt_two_pt(stats['l3_two_pt_allowed_conv'], stats['l3_two_pt_allowed_att'])}{SRC_PBP}</li>
         </ul>
       </div>
     </div>

--- a/scripts/game_prep_brief/sections/trenches.py
+++ b/scripts/game_prep_brief/sections/trenches.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from .delta import metric_delta_html, metric_delta_md
+from ._sources import SRC_PBP, SRC_CFB
 
 
 def _games(team: dict) -> list[dict]:
@@ -123,15 +124,15 @@ def _team_html(team: dict) -> str:
       <div class="block">
         <h4>Sacks (CFBStats)</h4>
         <ul>
-          <li>Sacks Allowed/Game: {_fmt(t['sacks_allowed_pg'])} (total {_fmt(t['sacks_allowed_total'])}, rank #{t['sacks_off_rank'] or 'N/A'})</li>
-          <li>Sacks Made/Game: {_fmt(t['sacks_for_pg'])} (total {_fmt(t['sacks_for_total'])}, rank #{t['sacks_def_rank'] or 'N/A'})</li>
+          <li>Sacks Allowed/Game: {_fmt(t['sacks_allowed_pg'])} (total {_fmt(t['sacks_allowed_total'])}, rank #{t['sacks_off_rank'] or 'N/A'}){SRC_CFB}</li>
+          <li>Sacks Made/Game: {_fmt(t['sacks_for_pg'])} (total {_fmt(t['sacks_for_total'])}, rank #{t['sacks_def_rank'] or 'N/A'}){SRC_CFB}</li>
         </ul>
       </div>
       <div class="block">
         <h4>TFL (Off CFBStats + Def PBP)</h4>
         <ul>
-          <li>TFL Allowed/Game: {_fmt(t['tfl_allowed_pg'])} (total {_fmt(t['tfl_allowed_total'])}, rank #{t['tfl_off_rank'] or 'N/A'})</li>
-          <li>Rush TFL Made/Game (PBP): {_fmt(t['rush_tfl_for_pg'])} (total {_fmt(t['rush_tfl_for_total'])})</li>
+          <li>TFL Allowed/Game: {_fmt(t['tfl_allowed_pg'])} (total {_fmt(t['tfl_allowed_total'])}, rank #{t['tfl_off_rank'] or 'N/A'}){SRC_CFB}</li>
+          <li>Rush TFL Made/Game (PBP): {_fmt(t['rush_tfl_for_pg'])} (total {_fmt(t['rush_tfl_for_total'])}){SRC_PBP}</li>
         </ul>
       </div>
     </div>

--- a/scripts/game_prep_brief/sections/turnovers.py
+++ b/scripts/game_prep_brief/sections/turnovers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from ._sources import SRC_PBP
+
 
 def _games(team: dict) -> list[dict]:
     pbp = team.get("pbp_entry") or {}
@@ -183,24 +185,24 @@ def _team_html(team: dict) -> str:
       <div class="block">
         <h4>Season Totals</h4>
         <ul>
-          <li>Turnovers Gained/Lost: {totals['gained']} / {totals['lost']}</li>
-          <li>Margin: {margin if margin is not None else 'N/A'}</li>
+          <li>Turnovers Gained/Lost: {totals['gained']} / {totals['lost']}{SRC_PBP}</li>
+          <li>Margin: {margin if margin is not None else 'N/A'}{SRC_PBP}</li>
         </ul>
       </div>
       {last_n_html}
       <div class="block">
         <h4>Breakdown</h4>
         <ul>
-          <li>INT Gained/Lost: {totals['int_gained']} / {totals['int_lost']}</li>
-          <li>Fumbles Gained/Lost: {totals['fum_gained']} / {totals['fum_lost']}</li>
+          <li>INT Gained/Lost: {totals['int_gained']} / {totals['int_lost']}{SRC_PBP}</li>
+          <li>Fumbles Gained/Lost: {totals['fum_gained']} / {totals['fum_lost']}{SRC_PBP}</li>
         </ul>
       </div>
       <div class="block">
         <h4>Points Off Turnovers</h4>
         <ul>
-          <li>Offense (off takeaways): {totals['pts_for']} total ({season_off_pg}/gm)</li>
-          <li>Defense (allowed off giveaways): {totals['pts_against']} total ({season_def_pg}/gm)</li>
-          <li>Avg Points per Post-TO Drive: {avg_pts_text}</li>
+          <li>Offense (off takeaways): {totals['pts_for']} total ({season_off_pg}/gm){SRC_PBP}</li>
+          <li>Defense (allowed off giveaways): {totals['pts_against']} total ({season_def_pg}/gm){SRC_PBP}</li>
+          <li>Avg Points per Post-TO Drive: {avg_pts_text}{SRC_PBP}</li>
         </ul>
       </div>
       <div class="block">

--- a/scripts/game_prep_brief/sections/two_point.py
+++ b/scripts/game_prep_brief/sections/two_point.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from .delta import metric_delta_html, metric_delta_md
+from ._sources import SRC_PBP
 
 
 def _games(team: dict) -> list[dict]:
@@ -75,15 +76,15 @@ def _team_html(team: dict) -> str:
       <div class="block">
         <h4>Season Totals</h4>
         <ul>
-          <li>Offense: {t['off_conv']}/{t['off_att']} ({off_pct})</li>
-          <li>Defense Allowed: {t['def_conv']}/{t['def_att']} ({def_pct})</li>
+          <li>Offense: {t['off_conv']}/{t['off_att']} ({off_pct}){SRC_PBP}</li>
+          <li>Defense Allowed: {t['def_conv']}/{t['def_att']} ({def_pct}){SRC_PBP}</li>
         </ul>
       </div>
       <div class="block">
         <h4>Offense Split</h4>
         <ul>
-          <li>Rush: {t['off_rush_conv']}/{t['off_rush_att']}</li>
-          <li>Pass: {t['off_pass_conv']}/{t['off_pass_att']}</li>
+          <li>Rush: {t['off_rush_conv']}/{t['off_rush_att']}{SRC_PBP}</li>
+          <li>Pass: {t['off_pass_conv']}/{t['off_pass_att']}{SRC_PBP}</li>
         </ul>
       </div>
       <div class="block">

--- a/scripts/game_prep_brief/sections/zones.py
+++ b/scripts/game_prep_brief/sections/zones.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import sys
 
+from ._sources import SRC_PBP, SRC_CFB
+
 
 def _games(team: dict) -> list[dict]:
     pbp = team.get("pbp_entry") or {}
@@ -191,30 +193,30 @@ def _team_html(team: dict, stats: dict) -> str:
       <div class="block">
         <h4>Green Zone (Inside 30)</h4>
         <ul>
-          <li>Trips: {stats['gz_trips']}{_last_n_compare(stats['gz_trips'], l3_gz_trips)}</li>
-          <li>TDs: {stats['gz_tds']}{_last_n_compare(stats['gz_tds'], l3_gz_tds)}</li>
-          <li>FGs: {stats['gz_fgs']}</li>
-          <li>Success: {stats['gz_success']}%{_last_n_compare(stats['gz_success'], l3_gz_success, suffix="%", show_arrow=True)}</li>
+          <li>Trips: {stats['gz_trips']}{_last_n_compare(stats['gz_trips'], l3_gz_trips)}{SRC_PBP}</li>
+          <li>TDs: {stats['gz_tds']}{_last_n_compare(stats['gz_tds'], l3_gz_tds)}{SRC_PBP}</li>
+          <li>FGs: {stats['gz_fgs']}{SRC_PBP}</li>
+          <li>Success: {stats['gz_success']}%{_last_n_compare(stats['gz_success'], l3_gz_success, suffix="%", show_arrow=True)}{SRC_PBP}</li>
         </ul>
       </div>
       <div class="block">
         <h4>Red Zone</h4>
         <ul>
-          <li>Trips: {stats['rz_trips']}{_last_n_compare(stats['rz_trips'], l3_rz_trips)}</li>
-          <li>TDs: {stats['rz_tds']}{_last_n_compare(stats['rz_tds'], l3_rz_tds)}</li>
-          <li>FGs: {stats['rz_fgs']}{_last_n_compare(stats['rz_fgs'], l3_rz_fgs)}</li>
-          <li>TD%: {stats['rz_td_pct']}%{_last_n_compare(stats['rz_td_pct'], l3_rz_td_pct, suffix="%", show_arrow=True)}</li>
-          <li>Efficiency: {stats['rz_eff']}%</li>
-          <li>CFBStats Rank: {rz_rank}</li>
+          <li>Trips: {stats['rz_trips']}{_last_n_compare(stats['rz_trips'], l3_rz_trips)}{SRC_PBP}</li>
+          <li>TDs: {stats['rz_tds']}{_last_n_compare(stats['rz_tds'], l3_rz_tds)}{SRC_PBP}</li>
+          <li>FGs: {stats['rz_fgs']}{_last_n_compare(stats['rz_fgs'], l3_rz_fgs)}{SRC_PBP}</li>
+          <li>TD%: {stats['rz_td_pct']}%{_last_n_compare(stats['rz_td_pct'], l3_rz_td_pct, suffix="%", show_arrow=True)}{SRC_PBP}</li>
+          <li>Efficiency: {stats['rz_eff']}%{SRC_PBP}</li>
+          <li>CFBStats Rank: {rz_rank}{SRC_CFB}</li>
         </ul>
       </div>
       <div class="block">
         <h4>Tight Red Zone (Inside 10)</h4>
         <ul>
-          <li>Trips: {stats['trz_trips']}{_last_n_compare(stats['trz_trips'], l3_trz_trips)}</li>
-          <li>TDs: {stats['trz_tds']}{_last_n_compare(stats['trz_tds'], l3_trz_tds)}</li>
-          <li>FGs: {stats['trz_fgs']}{_last_n_compare(stats['trz_fgs'], l3_trz_fgs)}</li>
-          <li>TD%: {stats['trz_td_pct']}%{_last_n_compare(stats['trz_td_pct'], l3_trz_td_pct, suffix="%", show_arrow=True)}</li>
+          <li>Trips: {stats['trz_trips']}{_last_n_compare(stats['trz_trips'], l3_trz_trips)}{SRC_PBP}</li>
+          <li>TDs: {stats['trz_tds']}{_last_n_compare(stats['trz_tds'], l3_trz_tds)}{SRC_PBP}</li>
+          <li>FGs: {stats['trz_fgs']}{_last_n_compare(stats['trz_fgs'], l3_trz_fgs)}{SRC_PBP}</li>
+          <li>TD%: {stats['trz_td_pct']}%{_last_n_compare(stats['trz_td_pct'], l3_trz_td_pct, suffix="%", show_arrow=True)}{SRC_PBP}</li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Add superscript source labels (`pbp`, `cfb`, `pff`) to each datapoint in the HTML game prep brief
- New `_sources.py` helper with shared source tag constants
- CSS styling for `sup.src` class and a visible legend in the header
- Annotated all 13 section files with appropriate source tags (290 total: 134 pbp, 141 cfb, 15 pff)

## Test plan
- [x] All section modules import cleanly
- [x] Brief regenerates successfully with source indicators visible
- [x] No "No PBP data" fallbacks — all data loads correctly
- [ ] Visual review of HTML output in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)