### PR TITLE
fix: compact print layout for game prep brief

### DIFF
--- a/scripts/game_prep_brief/__main__.py
+++ b/scripts/game_prep_brief/__main__.py
@@ -74,6 +74,11 @@ def parse_args():
         action="store_true",
         help="Allow live enrichment fetch during render if enrichment file is missing/stale.",
     )
+    p.add_argument(
+        "--legacy-page-breaks",
+        action="store_true",
+        help="Keep forcing each section onto a new print page (older whitespace-heavy behavior).",
+    )
     return p.parse_args()
 
 
@@ -157,7 +162,14 @@ def main():
             print(md)
 
     if args.format in ("html", "both"):
-        html = html_renderer.render(section_list, team1, team2, args.week, args.season)
+        html = html_renderer.render(
+            section_list,
+            team1,
+            team2,
+            args.week,
+            args.season,
+            compact_print=not args.legacy_page_breaks,
+        )
         path = args.output_dir / f"{base_name}.html"
         path.write_text(html)
         print(f"[ok] HTML → {path}", file=sys.stderr)

--- a/scripts/game_prep_brief/renderers/html.py
+++ b/scripts/game_prep_brief/renderers/html.py
@@ -150,7 +150,15 @@ def _section_verification_alert(section_key: str, team1: dict, team2: dict) -> s
     return " | ".join(team_notices)
 
 
-def render(sections: list[dict], team1: dict, team2: dict, week: int | None, season: int) -> str:
+def render(
+    sections: list[dict],
+    team1: dict,
+    team2: dict,
+    week: int | None,
+    season: int,
+    *,
+    compact_print: bool = True,
+) -> str:
     """Render full HTML with page breaks between sections."""
     now = datetime.now().strftime("%B %d, %Y %H:%M")
     week_str = f"Week {week} · " if week else ""
@@ -283,10 +291,42 @@ def render(sections: list[dict], team1: dict, team2: dict, week: int | None, sea
     .page-break:first-child {{ page-break-before: auto; }}
 
     @media print {{
-      body {{ background: white; padding: 12px; }}
-      .section {{ box-shadow: none; border: 1px solid #ddd; }}
-      .header {{ box-shadow: none; }}
-      @page {{ margin: 1cm; }}
+      body {{
+        background: white;
+        padding: 0;
+        font-size: 11px;
+      }}
+      .section {{
+        box-shadow: none;
+        border: 1px solid #ddd;
+        border-radius: 8px;
+        padding: 10px 12px 12px;
+        margin-bottom: 8px;
+      }}
+      .header {{
+        box-shadow: none;
+        margin-bottom: 10px;
+        padding: 12px 14px;
+      }}
+      .header h1 {{ font-size: 18px; }}
+      .header .subtitle {{ font-size: 12px; margin-top: 4px; }}
+      .section-header {{
+        margin-bottom: 8px;
+        padding-bottom: 4px;
+        font-size: 12px;
+      }}
+      .rankings-table {{ margin-bottom: 8px; }}
+      .rankings-table th,
+      .rankings-table td {{
+        padding: 4px 6px;
+        font-size: 10.5px;
+      }}
+      .block h4 {{ margin: 7px 0 4px; }}
+      .block li {{ margin: 1px 0; font-size: 10.5px; }}
+      .warning {{ margin-top: 6px; padding: 6px 8px; font-size: 10.5px; }}
+      .metric-compare {{ margin: 6px 0 8px; }}
+      @page {{ margin: 0.45in; }}
+      {" .page-break { page-break-before: auto !important; break-before: auto !important; }" if compact_print else ""}
     }}
     @media (max-width: 900px) {{
       .section-grid {{ grid-template-columns: 1fr; }}


### PR DESCRIPTION
## Summary
- reduce print whitespace in game prep brief HTML renderer
- default to compact print flow by disabling forced per-section page breaks in print media
- tighten print spacing (margins, paddings, table cell density, section/header spacing)
- add `--legacy-page-breaks` CLI flag to preserve old page-per-section behavior when needed

## Files
- `scripts/game_prep_brief/renderers/html.py`
- `scripts/game_prep_brief/__main__.py`

## Notes
- Change is print-only; screen layout remains unchanged.
- Generated outputs were intentionally not committed.
