### PR TITLE
Define published artifact contract

### DIFF
--- a/.github/workflows/brief-live-refresh.yml
+++ b/.github/workflows/brief-live-refresh.yml
@@ -55,13 +55,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
-      ARTIFACT_ROOT: ${{ runner.temp }}/brief_live_refresh
-      BUNDLE_PATH: ${{ runner.temp }}/brief_live_refresh/bundle/pbp_stats_bundle_${{ inputs.season }}.json
-      SNAPSHOT_PATH: ${{ runner.temp }}/brief_live_refresh/cfbstats/cfbstats_${{ inputs.season }}.json
-      VERIFICATION_REPORT_PATH: ${{ runner.temp }}/brief_live_refresh/cfbstats/cfbstats_verification_${{ inputs.season }}.json
-      ENRICHMENT_FILE: ${{ runner.temp }}/brief_live_refresh/enrichment/game_prep_enrichment_${{ inputs.season }}.json
-      BRIEF_OUTPUT_DIR: ${{ runner.temp }}/brief_live_refresh/brief
-      SUMMARY_JSON: ${{ runner.temp }}/brief_live_refresh/summary/game_prep_pipeline_summary.json
+      PUBLISHED_ROOT: ${{ runner.temp }}/brief_live_refresh/published/${{ inputs.season }}
+      SCRATCH_ROOT: ${{ runner.temp }}/brief_live_refresh/scratch
+      BUNDLE_PATH: ${{ runner.temp }}/brief_live_refresh/published/${{ inputs.season }}/pbp_stats_bundle_${{ inputs.season }}.json
+      SNAPSHOT_PATH: ${{ runner.temp }}/brief_live_refresh/published/${{ inputs.season }}/cfbstats_${{ inputs.season }}.json
+      VERIFICATION_REPORT_PATH: ${{ runner.temp }}/brief_live_refresh/published/${{ inputs.season }}/cfbstats_verification_${{ inputs.season }}.json
+      ENRICHMENT_FILE: ${{ runner.temp }}/brief_live_refresh/scratch/game_prep_enrichment_${{ inputs.season }}.json
+      BRIEF_OUTPUT_DIR: ${{ runner.temp }}/brief_live_refresh/scratch/brief
+      SUMMARY_JSON: ${{ runner.temp }}/brief_live_refresh/published/${{ inputs.season }}/game_prep_pipeline_summary_${{ inputs.season }}.json
     defaults:
       run:
         working-directory: pbp-analysis
@@ -111,11 +112,9 @@ jobs:
       - name: Prepare artifact paths
         run: |
           mkdir -p \
-            "${ARTIFACT_ROOT}/bundle" \
-            "${ARTIFACT_ROOT}/cfbstats" \
-            "${ARTIFACT_ROOT}/enrichment" \
-            "${ARTIFACT_ROOT}/brief" \
-            "${ARTIFACT_ROOT}/summary"
+            "${PUBLISHED_ROOT}" \
+            "${SCRATCH_ROOT}" \
+            "${BRIEF_OUTPUT_DIR}"
 
       - name: Run live refresh pipeline
         env:
@@ -185,6 +184,7 @@ jobs:
                       f"- Verification fails: `{validation.get('verification_fail_count')}`",
                       f"- Verification warnings: `{validation.get('verification_warning_count')}`",
                       f"- Smoke brief passed: `{validation.get('smoke_brief_passed')}`",
+                      f"- Publishable: `{(summary.get('artifact_contract') or {}).get('publishable')}`",
                   ]
               )
           with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as handle:
@@ -207,10 +207,18 @@ jobs:
           path: ${{ env.BRIEF_OUTPUT_DIR }}
           if-no-files-found: warn
 
-      - name: Upload full live-refresh artifacts
+      - name: Upload published artifact set
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: brief-live-refresh-artifacts
-          path: ${{ env.ARTIFACT_ROOT }}
+          name: brief-live-refresh-published-artifacts
+          path: ${{ env.PUBLISHED_ROOT }}
+          if-no-files-found: warn
+
+      - name: Upload scratch artifact set
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: brief-live-refresh-scratch-artifacts
+          path: ${{ env.SCRATCH_ROOT }}
           if-no-files-found: warn

--- a/.github/workflows/brief-pipeline-validation.yml
+++ b/.github/workflows/brief-pipeline-validation.yml
@@ -6,6 +6,7 @@ on:
       - ".github/workflows/brief-live-refresh.yml"
       - ".github/workflows/brief-pipeline-validation.yml"
       - "docs/demo-runbook.md"
+      - "docs/published-artifact-contract.md"
       - "scripts/refresh-game-prep-pipeline.sh"
       - "scripts/game_prep_brief/**"
       - "tests/**"

--- a/docs/demo-runbook.md
+++ b/docs/demo-runbook.md
@@ -58,9 +58,30 @@ Workflow behavior:
 - uploads:
   - `brief-live-refresh-summary`
   - `brief-live-refresh-smoke-brief`
-  - `brief-live-refresh-artifacts`
+  - `brief-live-refresh-published-artifacts`
+  - `brief-live-refresh-scratch-artifacts`
 
-The full artifact upload contains the generated bundle, CFBStats snapshot, verification report, enrichment file, smoke brief outputs, and the summary JSON for that run.
+The published artifact upload contains the season-scoped core set:
+
+- bundle
+- CFBStats snapshot
+- verification report
+- pipeline summary JSON
+
+The scratch artifact upload contains run-scoped helper outputs:
+
+- enrichment file
+- smoke brief outputs
+
+### Published Contract
+
+The published artifact contract is documented in [published-artifact-contract.md](./published-artifact-contract.md).
+
+Short version:
+
+- published production inputs live under `published/<season>/`
+- enrichment and smoke brief outputs are `scratch` artifacts, not part of the published contract
+- `artifact_contract` inside the summary JSON is the machine-readable source of truth for whether a run is publishable
 
 ### Offline Validate
 

--- a/docs/published-artifact-contract.md
+++ b/docs/published-artifact-contract.md
@@ -1,0 +1,76 @@
+# Published Artifact Contract
+
+This document defines the production artifact contract for the game prep brief refresh pipeline.
+
+## Contract Version
+
+- `artifact_contract.version = 1`
+
+The machine-readable source of truth for the contract is the pipeline summary JSON written by `scripts/refresh-game-prep-pipeline.sh`.
+
+## Published Artifact Set
+
+The official published artifact set is the season-scoped core output required by downstream consumers:
+
+- `bundle`: `published/<season>/pbp_stats_bundle_<season>.json`
+- `cfbstats_snapshot`: `published/<season>/cfbstats_<season>.json`
+- `cfbstats_verification_report`: `published/<season>/cfbstats_verification_<season>.json`
+- `pipeline_summary`: `published/<season>/game_prep_pipeline_summary_<season>.json`
+
+These are the only artifacts that should be treated as stable production inputs.
+
+## Scratch Outputs
+
+The pipeline also produces run-scoped scratch outputs:
+
+- enrichment JSON
+- smoke brief output directory
+- smoke brief markdown/html files
+
+These outputs are useful for operator validation, but they are not part of the published contract and downstream consumers should not depend on their paths.
+
+This distinction is intentional:
+
+- enrichment remains a run helper until issue `#189` defines it as a first-class artifact
+- smoke briefs are validation outputs, not canonical data inputs
+
+## Publishable Run Criteria
+
+A run is considered `publishable` only when all of the following are true:
+
+- `mode == "live-refresh"`
+- `exit_code == 0`
+- `validation.verification_fail_count == 0`
+- `validation.smoke_brief_passed == true`
+- every required published artifact exists
+
+The summary JSON records this under:
+
+- `artifact_contract.artifact_set_id`
+- `artifact_contract.publishable`
+- `artifact_contract.non_publishable_reasons`
+- `artifact_contract.published_set_complete`
+
+## Consumer Contract
+
+Downstream consumers should:
+
+- resolve stable production inputs from the `published/<season>/` set
+- use `artifact_contract.published_artifacts` to discover the logical artifact names and expected relative paths
+- ignore `artifact_contract.scratch_artifacts` for production consumption
+
+If a consumer needs to distinguish a scratch/local run from a publishable run, it should read:
+
+- `mode`
+- `exit_code`
+- `artifact_contract.publishable`
+- `artifact_contract.non_publishable_reasons`
+
+## Workflow Mapping
+
+The GitHub Actions live-refresh workflow writes artifacts into:
+
+- `published/<season>/...` for the published core set
+- `scratch/...` for run-scoped validation outputs
+
+This layout exists inside the uploaded workflow artifacts even before a persistent publishing service is added.

--- a/scripts/refresh-game-prep-pipeline.sh
+++ b/scripts/refresh-game-prep-pipeline.sh
@@ -597,6 +597,8 @@ write_summary_json() {
   SEASON="${SEASON}" \
   TEAM1="${TEAM1}" \
   TEAM2="${TEAM2}" \
+  TEAM1_SLUG="${TEAM1_SLUG}" \
+  TEAM2_SLUG="${TEAM2_SLUG}" \
   BUNDLE_PATH="${BUNDLE_PATH}" \
   SNAPSHOT_PATH="${SNAPSHOT_PATH}" \
   VERIFICATION_REPORT_PATH="${VERIFICATION_REPORT_PATH}" \
@@ -673,6 +675,36 @@ def _path_or_none(value: str | None) -> str | None:
     return str(Path(value).expanduser().resolve(strict=False))
 
 
+def _path_exists(value: str | None, *, assume_exists: bool = False) -> bool:
+    if assume_exists:
+        return True
+    if not value:
+        return False
+    return Path(value).exists()
+
+
+def _artifact_entry(
+    *,
+    logical_name: str,
+    path_value: str | None,
+    tier: str,
+    required: bool,
+    relative_path: str | None,
+    scope: str,
+    assume_exists: bool = False,
+) -> dict:
+    path = _path_or_none(path_value)
+    return {
+        "logical_name": logical_name,
+        "path": path,
+        "exists": _path_exists(path, assume_exists=assume_exists),
+        "tier": tier,
+        "scope": scope,
+        "required": required,
+        "relative_path": relative_path,
+    }
+
+
 def _stage_status(rows: list[dict], name: str) -> str | None:
     for row in rows:
         if row["name"] == name:
@@ -683,12 +715,119 @@ def _stage_status(rows: list[dict], name: str) -> str | None:
 stages = _read_stage_rows(Path(os.environ["STAGE_FILE"]))
 warnings = _read_warning_lines(Path(os.environ["WARNINGS_FILE"]))
 verification_counts = _read_counts(Path(os.environ["VERIFICATION_COUNTS_FILE"]))
+season = int(os.environ["SEASON"])
+team1 = os.environ["TEAM1"]
+team2 = os.environ["TEAM2"]
+team1_slug = os.environ["TEAM1_SLUG"]
+team2_slug = os.environ["TEAM2_SLUG"]
+analysis_ref = os.environ.get("ANALYSIS_REF") or None
+parser_ref = os.environ.get("PARSER_REF") or None
+summary_path = _path_or_none(os.environ.get("SUMMARY_JSON"))
+generated_timestamp = datetime.now(timezone.utc)
+generated_at = generated_timestamp.isoformat()
+generated_tag = generated_timestamp.strftime("%Y%m%dT%H%M%SZ")
+brief_markdown_relative = (
+    f"scratch/brief/{team1_slug}_vs_{team2_slug}_{season}_v2.md"
+    if os.environ.get("BRIEF_MARKDOWN_PATH")
+    else None
+)
+brief_html_relative = (
+    f"scratch/brief/{team1_slug}_vs_{team2_slug}_{season}_v2.html"
+    if os.environ.get("BRIEF_HTML_PATH")
+    else None
+)
+
+published_artifacts = {
+    "bundle": _artifact_entry(
+        logical_name="bundle",
+        path_value=os.environ.get("BUNDLE_PATH"),
+        tier="published",
+        scope="season",
+        required=True,
+        relative_path=f"published/{season}/pbp_stats_bundle_{season}.json",
+    ),
+    "cfbstats_snapshot": _artifact_entry(
+        logical_name="cfbstats_snapshot",
+        path_value=os.environ.get("SNAPSHOT_PATH"),
+        tier="published",
+        scope="season",
+        required=True,
+        relative_path=f"published/{season}/cfbstats_{season}.json",
+    ),
+    "cfbstats_verification_report": _artifact_entry(
+        logical_name="cfbstats_verification_report",
+        path_value=os.environ.get("VERIFICATION_REPORT_PATH"),
+        tier="published",
+        scope="season",
+        required=True,
+        relative_path=f"published/{season}/cfbstats_verification_{season}.json",
+    ),
+    "pipeline_summary": _artifact_entry(
+        logical_name="pipeline_summary",
+        path_value=os.environ.get("SUMMARY_JSON"),
+        tier="published",
+        scope="run",
+        required=True,
+        relative_path=f"published/{season}/game_prep_pipeline_summary_{season}.json",
+        assume_exists=True,
+    ),
+}
+
+scratch_artifacts = {
+    "enrichment": _artifact_entry(
+        logical_name="enrichment",
+        path_value=os.environ.get("ENRICHMENT_FILE"),
+        tier="scratch",
+        scope="run",
+        required=False,
+        relative_path=f"scratch/game_prep_enrichment_{season}.json",
+    ),
+    "smoke_brief_output_dir": _artifact_entry(
+        logical_name="smoke_brief_output_dir",
+        path_value=os.environ.get("OUTPUT_DIR"),
+        tier="scratch",
+        scope="run",
+        required=False,
+        relative_path="scratch/brief/",
+    ),
+    "smoke_brief_markdown": _artifact_entry(
+        logical_name="smoke_brief_markdown",
+        path_value=os.environ.get("BRIEF_MARKDOWN_PATH"),
+        tier="scratch",
+        scope="run",
+        required=False,
+        relative_path=brief_markdown_relative,
+    ),
+    "smoke_brief_html": _artifact_entry(
+        logical_name="smoke_brief_html",
+        path_value=os.environ.get("BRIEF_HTML_PATH"),
+        tier="scratch",
+        scope="run",
+        required=False,
+        relative_path=brief_html_relative,
+    ),
+}
+
+published_set_complete = all(entry["exists"] for entry in published_artifacts.values())
+non_publishable_reasons: list[str] = []
+if os.environ["MODE"] != "live-refresh":
+    non_publishable_reasons.append("mode_must_be_live_refresh")
+if int(os.environ["FINAL_EXIT_CODE"]) != 0:
+    non_publishable_reasons.append("pipeline_exit_nonzero")
+if verification_counts["fail"] > 0:
+    non_publishable_reasons.append("verification_fail_metrics_present")
+if _stage_status(stages, "smoke_brief") != "passed":
+    non_publishable_reasons.append("smoke_brief_failed")
+if not published_set_complete:
+    non_publishable_reasons.append("published_artifact_set_incomplete")
+publishable = not non_publishable_reasons
+artifact_set_id = f"{season}-{generated_tag}-{(analysis_ref or 'unknown')[:12]}"
 
 summary = {
-    "season": int(os.environ["SEASON"]),
-    "teams": [os.environ["TEAM1"], os.environ["TEAM2"]],
+    "season": season,
+    "teams": [team1, team2],
     "mode": os.environ["MODE"],
-    "generated_at": datetime.now(timezone.utc).isoformat(),
+    "generated_at": generated_at,
     "artifacts": {
         "bundle": _path_or_none(os.environ.get("BUNDLE_PATH")),
         "snapshot": _path_or_none(os.environ.get("SNAPSHOT_PATH")),
@@ -697,10 +836,11 @@ summary = {
         "brief_output_dir": _path_or_none(os.environ.get("OUTPUT_DIR")),
         "brief_markdown": _path_or_none(os.environ.get("BRIEF_MARKDOWN_PATH")),
         "brief_html": _path_or_none(os.environ.get("BRIEF_HTML_PATH")),
+        "summary_json": summary_path,
     },
     "git": {
-        "pbp_analysis_ref": os.environ.get("ANALYSIS_REF") or None,
-        "pbp_parser_ref": os.environ.get("PARSER_REF") or None,
+        "pbp_analysis_ref": analysis_ref,
+        "pbp_parser_ref": parser_ref,
     },
     "validation": {
         "parser_tests_passed": _stage_status(stages, "parser_tests") == "passed"
@@ -718,6 +858,17 @@ summary = {
     "strict_verification": os.environ.get("STRICT_VERIFICATION", "1") == "1",
     "brief_format": os.environ.get("BRIEF_FORMAT"),
     "exit_code": int(os.environ["FINAL_EXIT_CODE"]),
+    "artifact_contract": {
+        "version": 1,
+        "artifact_set_id": artifact_set_id,
+        "published_root_relative_path": f"published/{season}/",
+        "scratch_root_relative_path": "scratch/",
+        "published_set_complete": published_set_complete,
+        "publishable": publishable,
+        "non_publishable_reasons": non_publishable_reasons,
+        "published_artifacts": published_artifacts,
+        "scratch_artifacts": scratch_artifacts,
+    },
 }
 
 Path(os.environ["SUMMARY_JSON"]).write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")

--- a/tests/test_pipeline_summary_contract.py
+++ b/tests/test_pipeline_summary_contract.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PIPELINE_SCRIPT = ROOT / "scripts" / "refresh-game-prep-pipeline.sh"
+FIXTURES = ROOT / "tests" / "fixtures" / "pipeline"
+
+
+def test_offline_pipeline_summary_includes_artifact_contract(tmp_path: Path) -> None:
+    summary_json = tmp_path / "game_prep_pipeline_summary.json"
+    output_dir = tmp_path / "brief"
+    bundle_path = FIXTURES / "pbp_stats_bundle_2025.json"
+    snapshot_path = FIXTURES / "cfbstats_2025_snapshot.json"
+    verification_path = FIXTURES / "cfbstats_verification_2025_report.json"
+
+    env = os.environ.copy()
+    env["PBP_PIPELINE_PYTHON"] = sys.executable
+
+    subprocess.run(
+        [
+            str(PIPELINE_SCRIPT),
+            "Washington",
+            "Ohio State",
+            "--season",
+            "2025",
+            "--mode",
+            "offline-validate",
+            "--bundle-path",
+            str(bundle_path),
+            "--reuse-bundle",
+            "--cfbstats-snapshot",
+            str(snapshot_path),
+            "--cfbstats-verification-report",
+            str(verification_path),
+            "--no-enrichment",
+            "--skip-tests",
+            "--brief-format",
+            "markdown",
+            "--output-dir",
+            str(output_dir),
+            "--summary-json",
+            str(summary_json),
+        ],
+        check=True,
+        cwd=ROOT,
+        env=env,
+    )
+
+    summary = json.loads(summary_json.read_text(encoding="utf-8"))
+    contract = summary["artifact_contract"]
+
+    assert contract["version"] == 1
+    assert contract["published_root_relative_path"] == "published/2025/"
+    assert contract["scratch_root_relative_path"] == "scratch/"
+    assert contract["publishable"] is False
+    assert contract["published_set_complete"] is True
+    assert "mode_must_be_live_refresh" in contract["non_publishable_reasons"]
+
+    bundle = contract["published_artifacts"]["bundle"]
+    assert bundle["tier"] == "published"
+    assert bundle["required"] is True
+    assert bundle["relative_path"] == "published/2025/pbp_stats_bundle_2025.json"
+    assert bundle["exists"] is True
+
+    verification_report = contract["published_artifacts"]["cfbstats_verification_report"]
+    assert verification_report["relative_path"] == (
+        "published/2025/cfbstats_verification_2025.json"
+    )
+
+    enrichment = contract["scratch_artifacts"]["enrichment"]
+    assert enrichment["tier"] == "scratch"
+    assert enrichment["required"] is False
+    assert enrichment["relative_path"] == "scratch/game_prep_enrichment_2025.json"
+
+    markdown = contract["scratch_artifacts"]["smoke_brief_markdown"]
+    assert markdown["relative_path"] == "scratch/brief/washington_vs_ohio-state_2025_v2.md"


### PR DESCRIPTION
## Summary

This implements issue #187 by defining the published artifact contract for the brief pipeline.

The important decision in this PR is that the pipeline now distinguishes between:
- season-scoped published artifacts that downstream consumers can treat as stable production inputs
- run-scoped scratch artifacts that are useful for operator validation, but are not part of the published contract

That distinction is now documented, reflected in the live-refresh workflow layout, and exported in machine-readable form through the pipeline summary JSON.

## Contract decisions

### 1. The published artifact set is the season-scoped core data only

This PR defines the official published set as:
- `bundle` -> `published/<season>/pbp_stats_bundle_<season>.json`
- `cfbstats_snapshot` -> `published/<season>/cfbstats_<season>.json`
- `cfbstats_verification_report` -> `published/<season>/cfbstats_verification_<season>.json`
- `pipeline_summary` -> `published/<season>/game_prep_pipeline_summary_<season>.json`

Why:
- these are the canonical data artifacts the pipeline needs to serve or validate briefs
- they are season-scoped and stable enough to define as production inputs
- they already align with the parser ownership model established in the earlier refactor steps

### 2. Enrichment and smoke briefs remain scratch outputs

This PR explicitly does **not** make enrichment part of the published contract yet.

Scratch outputs are now:
- enrichment file
- smoke brief output directory
- smoke brief markdown/html files

Why:
- enrichment still does not have its final first-class artifact contract yet; that is issue #189
- smoke briefs are validation/render outputs, not canonical data dependencies

This is the cleanest way to answer issue #187 without pre-solving issue #189.

### 3. The summary JSON now exports the contract machine-readably

`scripts/refresh-game-prep-pipeline.sh` now writes an `artifact_contract` section into the summary JSON with:
- `version`
- `artifact_set_id`
- `published_root_relative_path`
- `scratch_root_relative_path`
- `published_set_complete`
- `publishable`
- `non_publishable_reasons`
- `published_artifacts`
- `scratch_artifacts`

Why this matters:
- downstream tools can distinguish publishable runs from scratch runs without guessing from paths
- the contract is now inspectable from a single machine-readable artifact
- a future publishing service can build on this without redefining the artifact boundaries again

### 4. A publishable run is now explicitly defined

A run is considered publishable only if:
- `mode == live-refresh`
- `exit_code == 0`
- verification fail count is `0`
- the smoke brief passed
- every required published artifact exists

If not, the summary JSON records the reason(s) in `artifact_contract.non_publishable_reasons`.

That gives operators and future automation a concrete publish gate instead of an implied one.

## Implementation details

### Pipeline summary contract

Updated `scripts/refresh-game-prep-pipeline.sh` so the summary JSON now includes:
- old fields preserved for compatibility
- new `artifacts.summary_json`
- new `artifact_contract` section with logical artifact names, tiers, required flags, actual paths, and expected relative paths

I kept the original top-level `artifacts` map so existing consumers of the summary don’t need to be rewritten just to tolerate the new contract metadata.

### Live workflow artifact layout

Updated `.github/workflows/brief-live-refresh.yml` so live-refresh outputs are laid out as:
- `published/<season>/...` for published core artifacts
- `scratch/...` for run-scoped validation outputs

Workflow artifact uploads now mirror that distinction:
- `brief-live-refresh-summary`
- `brief-live-refresh-smoke-brief`
- `brief-live-refresh-published-artifacts`
- `brief-live-refresh-scratch-artifacts`

The workflow summary also now shows whether the run is publishable.

### Documentation

Added `docs/published-artifact-contract.md` to define:
- the official artifact set
- naming/path conventions
- publishable-run criteria
- consumer expectations

Also updated `docs/demo-runbook.md` so the operator docs match the new workflow artifact naming and contract language.

### Test coverage

Added `tests/test_pipeline_summary_contract.py`.

This test runs the pipeline in `offline-validate` mode against pinned fixtures and asserts that:
- `artifact_contract.version == 1`
- the published root expectation is `published/<season>/`
- the scratch root expectation is `scratch/`
- the published artifact entries use the expected relative paths
- the scratch artifact entries are classified as scratch
- offline validation is correctly marked as **not publishable** with the expected reason

This gives the new contract a schema/behavior guard instead of leaving it doc-only.

## Validation

Ran:
- `PYTHONPATH=. /Users/victorres/projects2/pbp/.venv/bin/python -m pytest -q tests/test_pipeline_summary_contract.py tests/test_game_prep_loader_artifacts.py tests/test_scoring_zones_issue_158.py`

Result:
- `6 passed`

## Why this is the right scope for #187

Issue #187 is about defining the published contract, not building the publishing mechanism.

So this PR stops at:
- explicit contract
- explicit machine-readable metadata
- explicit workflow layout
- explicit docs/tests

And intentionally leaves these for later:
- #189 first-class enrichment contract
- any persistent artifact publishing service
- scheduled automation / observability follow-ons
