### PR TITLE
Fix live refresh workflow temp path resolution

### DIFF
--- a/.github/workflows/brief-live-refresh.yml
+++ b/.github/workflows/brief-live-refresh.yml
@@ -59,15 +59,6 @@ jobs:
   live-refresh:
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    env:
-      PUBLISHED_ROOT: ${{ runner.temp }}/brief_live_refresh/published/${{ inputs.season }}
-      SCRATCH_ROOT: ${{ runner.temp }}/brief_live_refresh/scratch
-      BUNDLE_PATH: ${{ runner.temp }}/brief_live_refresh/published/${{ inputs.season }}/pbp_stats_bundle_${{ inputs.season }}.json
-      SNAPSHOT_PATH: ${{ runner.temp }}/brief_live_refresh/published/${{ inputs.season }}/cfbstats_${{ inputs.season }}.json
-      VERIFICATION_REPORT_PATH: ${{ runner.temp }}/brief_live_refresh/published/${{ inputs.season }}/cfbstats_verification_${{ inputs.season }}.json
-      ENRICHMENT_FILE: ${{ runner.temp }}/brief_live_refresh/scratch/game_prep_enrichment_${{ inputs.season }}.json
-      BRIEF_OUTPUT_DIR: ${{ runner.temp }}/brief_live_refresh/scratch/brief
-      SUMMARY_JSON: ${{ runner.temp }}/brief_live_refresh/published/${{ inputs.season }}/game_prep_pipeline_summary_${{ inputs.season }}.json
     defaults:
       run:
         working-directory: pbp-analysis
@@ -77,6 +68,20 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: pbp-analysis
+
+      - name: Resolve artifact paths
+        run: |
+          root="${RUNNER_TEMP}/brief_live_refresh"
+          {
+            echo "PUBLISHED_ROOT=${root}/published/${{ inputs.season }}"
+            echo "SCRATCH_ROOT=${root}/scratch"
+            echo "BUNDLE_PATH=${root}/published/${{ inputs.season }}/pbp_stats_bundle_${{ inputs.season }}.json"
+            echo "SNAPSHOT_PATH=${root}/published/${{ inputs.season }}/cfbstats_${{ inputs.season }}.json"
+            echo "VERIFICATION_REPORT_PATH=${root}/published/${{ inputs.season }}/cfbstats_verification_${{ inputs.season }}.json"
+            echo "ENRICHMENT_FILE=${root}/scratch/game_prep_enrichment_${{ inputs.season }}.json"
+            echo "BRIEF_OUTPUT_DIR=${root}/scratch/brief"
+            echo "SUMMARY_JSON=${root}/published/${{ inputs.season }}/game_prep_pipeline_summary_${{ inputs.season }}.json"
+          } >> "${GITHUB_ENV}"
 
       - name: Require main branch
         run: |


### PR DESCRIPTION
## Summary
- resolve live-refresh artifact paths in a setup step via `RUNNER_TEMP` and `GITHUB_ENV`
- remove the invalid job-level `${{ runner.temp }}` expressions that GitHub refuses to parse
- unblock manual `workflow_dispatch` runs for the baseline live-refresh work tracked in #198

## Validation
- verified the invalid `${{ runner.temp }}` references are removed from the workflow definition
- attempted `gh workflow run` before this fix and GitHub rejected dispatch with `Unrecognized named-value: runner`
