### PR TITLE
Publish season artifacts to GitHub releases

### DIFF
--- a/.github/workflows/brief-live-refresh.yml
+++ b/.github/workflows/brief-live-refresh.yml
@@ -49,7 +49,7 @@ on:
         default: true
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: brief-live-refresh
@@ -173,8 +173,65 @@ jobs:
 
           "${args[@]}"
 
+      - name: Prepare release publication
+        if: always()
+        id: publication
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [[ ! -f "${SUMMARY_JSON}" ]]; then
+            {
+              echo "publishable=false"
+              echo "release_tag=brief-artifacts-${{ inputs.season }}"
+              echo "release_name=Brief Published Artifacts ${{ inputs.season }}"
+              echo "release_url=https://github.com/${GITHUB_REPOSITORY}/releases/tag/brief-artifacts-${{ inputs.season }}"
+              echo "release_notes_path="
+            } >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          python -m scripts.game_prep_brief.published_release \
+            --summary-json "${SUMMARY_JSON}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --run-url "${RUN_URL}" \
+            --notes-path "${RUNNER_TEMP}/brief_published_artifacts_${{ inputs.season }}.md"
+
+      - name: Publish season artifact release
+        id: publish_release
+        if: success() && steps.publication.outputs.publishable == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${{ steps.publication.outputs.release_tag }}"
+          name="${{ steps.publication.outputs.release_name }}"
+          notes="${{ steps.publication.outputs.release_notes_path }}"
+
+          if gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            gh release edit "${tag}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --title "${name}" \
+              --notes-file "${notes}"
+          else
+            gh release create "${tag}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --title "${name}" \
+              --notes-file "${notes}" \
+              --target "${GITHUB_SHA}"
+          fi
+
+          gh release upload "${tag}" "${PUBLISHED_ROOT}"/* \
+            --repo "${GITHUB_REPOSITORY}" \
+            --clobber
+
+          echo "result=published" >> "${GITHUB_OUTPUT}"
+
       - name: Add workflow summary
         if: always()
+        env:
+          RELEASE_TAG: ${{ steps.publication.outputs.release_tag }}
+          RELEASE_URL: ${{ steps.publication.outputs.release_url }}
+          RELEASE_PUBLISHABLE: ${{ steps.publication.outputs.publishable }}
+          RELEASE_RESULT: ${{ steps.publish_release.outputs.result }}
         run: |
           python - <<'PY'
           from pathlib import Path
@@ -203,8 +260,16 @@ jobs:
                       f"- Verification warnings: `{validation.get('verification_warning_count')}`",
                       f"- Smoke brief passed: `{validation.get('smoke_brief_passed')}`",
                       f"- Publishable: `{(summary.get('artifact_contract') or {}).get('publishable')}`",
+                      f"- Published release tag: `{os.environ.get('RELEASE_TAG')}`",
                   ]
               )
+              release_result = os.environ.get("RELEASE_RESULT")
+              if release_result == "published":
+                  summary_lines.append(
+                      f"- Published release URL: {os.environ.get('RELEASE_URL')}"
+                  )
+              elif os.environ.get("RELEASE_PUBLISHABLE") == "false":
+                  summary_lines.append("- Published release: skipped (run was not publishable)")
               interrupted = (summary.get("run_state") or {}).get("interrupted_stages") or []
               slow_stages = (summary.get("observability") or {}).get("slow_stages") or []
               if interrupted:

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Notes:
 - Default XML bundle path: `../yr-data-api/data/pbp_stats_bundle.json`
   - Override with `GAME_PREP_XML_BUNDLE_PATH=/path/to/pbp_stats_bundle.json`
   - This `yr-data-api` path is a local handoff/convenience file for direct brief runs, not the official published artifact contract
+  - The canonical published bundle is released as `pbp_stats_bundle_<season>.json` on the season GitHub release `brief-artifacts-<season>`
 - Set `GAME_PREP_DATA_SOURCE=local` to force legacy `data.json` source.
 - Optionally overlays matchup-specific data from `matchups/<slug>/data.json`.
 - Coach/play-caller fields are currently placeholder `N/A` in this repo.

--- a/docs/demo-runbook.md
+++ b/docs/demo-runbook.md
@@ -47,7 +47,7 @@ Important: the `yr-data-api/data/pbp_stats_bundle.json` write is a **local hando
 
 ### GitHub Actions Live Refresh
 
-The official operator workflow is [`.github/workflows/brief-live-refresh.yml`](../.github/workflows/brief-live-refresh.yml). It runs the same `live-refresh` path as the local script, but writes every output into workflow artifacts instead of depending on `yr-data-api`.
+The official operator workflow is [`.github/workflows/brief-live-refresh.yml`](../.github/workflows/brief-live-refresh.yml). It runs the same `live-refresh` path as the local script, but publishes the season-core artifact set to a GitHub release instead of depending on `yr-data-api`.
 
 Requirements:
 
@@ -58,6 +58,7 @@ Workflow behavior:
 
 - checks out `pbp-analysis` and `pbp-parser`
 - runs `scripts/refresh-game-prep-pipeline.sh` in `live-refresh` mode
+- publishes successful season-core outputs to the GitHub release `brief-artifacts-<season>`
 - uploads:
   - `brief-live-refresh-summary`
   - `brief-live-refresh-smoke-brief`
@@ -73,12 +74,21 @@ The published artifact upload contains the season-scoped core set:
 
 This is the official published contract. It is distinct from the local `yr-data-api/data/pbp_stats_bundle.json` handoff path.
 
+Canonical retrieval path for the current season set:
+
+- release page: `https://github.com/victorres11/pbp-analysis/releases/tag/brief-artifacts-<season>`
+- direct downloads:
+  - `https://github.com/victorres11/pbp-analysis/releases/download/brief-artifacts-<season>/pbp_stats_bundle_<season>.json`
+  - `https://github.com/victorres11/pbp-analysis/releases/download/brief-artifacts-<season>/cfbstats_<season>.json`
+  - `https://github.com/victorres11/pbp-analysis/releases/download/brief-artifacts-<season>/cfbstats_verification_<season>.json`
+  - `https://github.com/victorres11/pbp-analysis/releases/download/brief-artifacts-<season>/game_prep_pipeline_summary_<season>.json`
+
 The scratch artifact upload contains run-scoped helper outputs:
 
 - enrichment file
 - smoke brief outputs
 
-By default the workflow refreshes and requires enrichment. If an operator intentionally disables enrichment, the run still completes, but the summary JSON marks it as non-publishable.
+By default the workflow refreshes and requires enrichment. If an operator intentionally disables enrichment, the run still completes, but the summary JSON marks it as non-publishable and the season GitHub release is not updated.
 
 ### Published Contract
 

--- a/docs/published-artifact-contract.md
+++ b/docs/published-artifact-contract.md
@@ -14,6 +14,20 @@ The machine-readable source of truth for the contract is the pipeline summary JS
 
 The local `yr-data-api/data/pbp_stats_bundle.json` handoff path is documented separately in [yr-data-api-bundle-role.md](./yr-data-api-bundle-role.md). It is not part of the official published artifact set.
 
+## Canonical Publication Target
+
+The canonical publication target is a season-scoped GitHub release in `victorres11/pbp-analysis`:
+
+- release tag: `brief-artifacts-<season>`
+- release title: `Brief Published Artifacts <season>`
+
+For example, the 2025 season core set is published at:
+
+- release page: `https://github.com/victorres11/pbp-analysis/releases/tag/brief-artifacts-2025`
+- direct asset base: `https://github.com/victorres11/pbp-analysis/releases/download/brief-artifacts-2025/`
+
+This release is a rolling target. Each successful publishable live-refresh run updates the assets in place for that season. Operators should treat the current assets on that release as the authoritative published set.
+
 ## Published Artifact Set
 
 The official published artifact set is the season-scoped core output required by downstream consumers:
@@ -30,6 +44,13 @@ Specifically, the sibling local path:
 - `yr-data-api/data/pbp_stats_bundle.json`
 
 is **not** a published production artifact. It remains a local handoff path for direct brief workflows.
+
+When published to GitHub Releases, these files are uploaded as flat release assets using the same filenames:
+
+- `pbp_stats_bundle_<season>.json`
+- `cfbstats_<season>.json`
+- `cfbstats_verification_<season>.json`
+- `game_prep_pipeline_summary_<season>.json`
 
 ## Scratch Outputs
 
@@ -58,6 +79,8 @@ A run is considered `publishable` only when all of the following are true:
 - `validation.smoke_brief_passed == true`
 - every required published artifact exists
 
+Only publishable runs update the season GitHub release. Non-publishable runs still upload workflow artifacts for debugging, but they do not mutate the canonical published release.
+
 The summary JSON records this under:
 
 - `artifact_contract.artifact_set_id`
@@ -69,9 +92,16 @@ The summary JSON records this under:
 
 Downstream consumers should:
 
-- resolve stable production inputs from the `published/<season>/` set
+- resolve stable production inputs from the `brief-artifacts-<season>` GitHub release
 - use `artifact_contract.published_artifacts` to discover the logical artifact names and expected relative paths
 - ignore `artifact_contract.scratch_artifacts` for production consumption
+
+Consumers that need direct download URLs can combine the release tag with the published filenames:
+
+- `https://github.com/victorres11/pbp-analysis/releases/download/brief-artifacts-<season>/pbp_stats_bundle_<season>.json`
+- `https://github.com/victorres11/pbp-analysis/releases/download/brief-artifacts-<season>/cfbstats_<season>.json`
+- `https://github.com/victorres11/pbp-analysis/releases/download/brief-artifacts-<season>/cfbstats_verification_<season>.json`
+- `https://github.com/victorres11/pbp-analysis/releases/download/brief-artifacts-<season>/game_prep_pipeline_summary_<season>.json`
 
 The one exception is the brief pipeline itself, which may require the run-scoped enrichment artifact depending on `enrichment_contract.policy`.
 
@@ -89,4 +119,15 @@ The GitHub Actions live-refresh workflow writes artifacts into:
 - `published/<season>/...` for the published core set
 - `scratch/...` for run-scoped validation outputs
 
-This layout exists inside the uploaded workflow artifacts even before a persistent publishing service is added.
+For publishable runs, the workflow then publishes the `published/<season>/...` contents to the season GitHub release.
+
+Workflow artifacts remain useful, but they are not the canonical publication target:
+
+- `brief-live-refresh-published-artifacts` and `brief-live-refresh-scratch-artifacts` are per-run operator/debug artifacts
+- GitHub release assets are the stable retrieval path for the current season-core set
+
+## Retention and Access
+
+- GitHub release assets should be treated as persistent until intentionally replaced by a newer publishable run for the same season.
+- GitHub Actions artifacts remain per-run provenance and follow the repository's workflow artifact retention policy.
+- Read access to the `victorres11/pbp-analysis` repository is sufficient to retrieve the published artifact release assets.

--- a/scripts/game_prep_brief/published_release.py
+++ b/scripts/game_prep_brief/published_release.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+def _published_asset_entries(summary: dict[str, Any], repo: str, release_tag: str) -> list[dict[str, str]]:
+    artifact_contract = summary.get("artifact_contract") or {}
+    published_artifacts = artifact_contract.get("published_artifacts") or {}
+    base_download_url = f"https://github.com/{repo}/releases/download/{release_tag}"
+
+    assets: list[dict[str, str]] = []
+    for logical_name in sorted(published_artifacts):
+        asset = published_artifacts[logical_name]
+        relative_path = asset.get("relative_path")
+        if not relative_path:
+            continue
+        filename = Path(relative_path).name
+        assets.append(
+            {
+                "logical_name": logical_name,
+                "filename": filename,
+                "download_url": f"{base_download_url}/{filename}",
+            }
+        )
+    return assets
+
+
+def build_release_metadata(
+    summary: dict[str, Any],
+    *,
+    repo: str,
+    run_url: str | None = None,
+) -> dict[str, Any]:
+    season = summary["season"]
+    release_tag = f"brief-artifacts-{season}"
+    release_name = f"Brief Published Artifacts {season}"
+    release_url = f"https://github.com/{repo}/releases/tag/{release_tag}"
+    assets = _published_asset_entries(summary, repo, release_tag)
+
+    validation = summary.get("validation") or {}
+    git_refs = summary.get("git") or {}
+    artifact_contract = summary.get("artifact_contract") or {}
+
+    notes_lines = [
+        f"# {release_name}",
+        "",
+        f"This release is the rolling canonical published artifact set for the {season} season.",
+        "Each successful publishable live-refresh run overwrites these release assets in place.",
+        "",
+        f"- Artifact set id: `{artifact_contract.get('artifact_set_id')}`",
+        f"- Generated at: `{summary.get('generated_at')}`",
+        f"- Teams: `{', '.join(summary.get('teams') or [])}`",
+        f"- pbp-analysis ref: `{git_refs.get('pbp_analysis_ref')}`",
+        f"- pbp-parser ref: `{git_refs.get('pbp_parser_ref')}`",
+        f"- Verification fails: `{validation.get('verification_fail_count')}`",
+        f"- Verification warnings: `{validation.get('verification_warning_count')}`",
+    ]
+    if run_url:
+        notes_lines.append(f"- Workflow run: {run_url}")
+    notes_lines.extend(
+        [
+            "",
+            "## Published Assets",
+        ]
+    )
+    for asset in assets:
+        notes_lines.append(
+            f"- `{asset['filename']}` (`{asset['logical_name']}`): {asset['download_url']}"
+        )
+
+    return {
+        "publishable": bool(artifact_contract.get("publishable")),
+        "release_tag": release_tag,
+        "release_name": release_name,
+        "release_url": release_url,
+        "assets": assets,
+        "notes": "\n".join(notes_lines) + "\n",
+    }
+
+
+def _write_github_output(outputs: dict[str, str]) -> None:
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if not github_output:
+        return
+
+    with open(github_output, "a", encoding="utf-8") as handle:
+        for key, value in outputs.items():
+            handle.write(f"{key}={value}\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Prepare GitHub release metadata for published brief artifacts."
+    )
+    parser.add_argument("--summary-json", required=True, type=Path)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--notes-path", required=True, type=Path)
+    parser.add_argument("--run-url")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    summary = json.loads(args.summary_json.read_text(encoding="utf-8"))
+    metadata = build_release_metadata(summary, repo=args.repo, run_url=args.run_url)
+
+    args.notes_path.parent.mkdir(parents=True, exist_ok=True)
+    args.notes_path.write_text(metadata["notes"], encoding="utf-8")
+
+    _write_github_output(
+        {
+            "publishable": "true" if metadata["publishable"] else "false",
+            "release_tag": metadata["release_tag"],
+            "release_name": metadata["release_name"],
+            "release_url": metadata["release_url"],
+            "release_notes_path": str(args.notes_path),
+        }
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_published_release.py
+++ b/tests/test_published_release.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from scripts.game_prep_brief.published_release import build_release_metadata
+
+
+def test_build_release_metadata_uses_season_scoped_release_assets() -> None:
+    summary = {
+        "season": 2025,
+        "generated_at": "2026-03-10T18:23:47.533830+00:00",
+        "teams": ["Washington", "Ohio State"],
+        "git": {
+            "pbp_analysis_ref": "analysis-sha",
+            "pbp_parser_ref": "parser-sha",
+        },
+        "validation": {
+            "verification_fail_count": 0,
+            "verification_warning_count": 0,
+        },
+        "artifact_contract": {
+            "artifact_set_id": "2025-20260310T182347Z-9cf24d85d886",
+            "publishable": True,
+            "published_artifacts": {
+                "bundle": {
+                    "relative_path": "published/2025/pbp_stats_bundle_2025.json",
+                },
+                "cfbstats_snapshot": {
+                    "relative_path": "published/2025/cfbstats_2025.json",
+                },
+                "cfbstats_verification_report": {
+                    "relative_path": "published/2025/cfbstats_verification_2025.json",
+                },
+                "pipeline_summary": {
+                    "relative_path": "published/2025/game_prep_pipeline_summary_2025.json",
+                },
+            },
+        },
+    }
+
+    metadata = build_release_metadata(
+        summary,
+        repo="victorres11/pbp-analysis",
+        run_url="https://github.com/victorres11/pbp-analysis/actions/runs/22916950471",
+    )
+
+    assert metadata["publishable"] is True
+    assert metadata["release_tag"] == "brief-artifacts-2025"
+    assert metadata["release_name"] == "Brief Published Artifacts 2025"
+    assert metadata["release_url"] == (
+        "https://github.com/victorres11/pbp-analysis/releases/tag/brief-artifacts-2025"
+    )
+    assert metadata["assets"] == [
+        {
+            "logical_name": "bundle",
+            "filename": "pbp_stats_bundle_2025.json",
+            "download_url": (
+                "https://github.com/victorres11/pbp-analysis/releases/download/"
+                "brief-artifacts-2025/pbp_stats_bundle_2025.json"
+            ),
+        },
+        {
+            "logical_name": "cfbstats_snapshot",
+            "filename": "cfbstats_2025.json",
+            "download_url": (
+                "https://github.com/victorres11/pbp-analysis/releases/download/"
+                "brief-artifacts-2025/cfbstats_2025.json"
+            ),
+        },
+        {
+            "logical_name": "cfbstats_verification_report",
+            "filename": "cfbstats_verification_2025.json",
+            "download_url": (
+                "https://github.com/victorres11/pbp-analysis/releases/download/"
+                "brief-artifacts-2025/cfbstats_verification_2025.json"
+            ),
+        },
+        {
+            "logical_name": "pipeline_summary",
+            "filename": "game_prep_pipeline_summary_2025.json",
+            "download_url": (
+                "https://github.com/victorres11/pbp-analysis/releases/download/"
+                "brief-artifacts-2025/game_prep_pipeline_summary_2025.json"
+            ),
+        },
+    ]
+    assert "rolling canonical published artifact set" in metadata["notes"]
+    assert "2025-20260310T182347Z-9cf24d85d886" in metadata["notes"]
+    assert "analysis-sha" in metadata["notes"]
+    assert "parser-sha" in metadata["notes"]
+    assert "22916950471" in metadata["notes"]
+
+
+def test_build_release_metadata_keeps_release_target_stable_for_non_publishable_runs() -> None:
+    summary = {
+        "season": 2025,
+        "teams": ["Washington", "Ohio State"],
+        "artifact_contract": {
+            "artifact_set_id": "artifact-id",
+            "publishable": False,
+            "published_artifacts": {},
+        },
+    }
+
+    metadata = build_release_metadata(summary, repo="victorres11/pbp-analysis")
+
+    assert metadata["publishable"] is False
+    assert metadata["release_tag"] == "brief-artifacts-2025"
+    assert metadata["release_url"].endswith("/brief-artifacts-2025")


### PR DESCRIPTION
## Summary
Implements `#199` by selecting GitHub release assets as the canonical publication target for the published brief artifact set.

After this change:
- the live-refresh workflow still uploads per-run Actions artifacts for debugging/provenance
- publishable live-refresh runs also update a stable season-scoped GitHub release
- operators and downstream consumers have a deterministic retrieval path for the current published artifact set without inspecting runner-local paths or Actions logs

## Publication Target Decision
I evaluated the options in the issue against what the system can actually operate today.

Chosen target: **GitHub release assets in `victorres11/pbp-analysis`**

Specifically:
- release tag: `brief-artifacts-<season>`
- release title: `Brief Published Artifacts <season>`
- published assets:
  - `pbp_stats_bundle_<season>.json`
  - `cfbstats_<season>.json`
  - `cfbstats_verification_<season>.json`
  - `game_prep_pipeline_summary_<season>.json`

Why this target:
- GitHub-native, so it works with the current repo/workflow model without adding another service
- stable retrieval URL per season
- persistent enough for production consumption, unlike expiring Actions artifacts
- keeps per-run provenance separate from the canonical current set

Why not Actions artifacts only:
- they are tied to individual runs
- they expire
- they do not provide a single stable season retrieval target

## Implementation
### Workflow
Updated `.github/workflows/brief-live-refresh.yml` to:
- grant `contents: write` so the workflow can publish release assets
- prepare release metadata from the pipeline summary via `scripts.game_prep_brief.published_release`
- create or update the season release `brief-artifacts-<season>`
- upload the season-core published artifact set to that release with `--clobber`
- keep the existing Actions artifact uploads unchanged
- add release tag / release URL information to the workflow summary

The publish step is gated on `artifact_contract.publishable == true`, so non-publishable runs still upload debug artifacts but do not mutate the canonical release.

### Helper
Added `scripts/game_prep_brief/published_release.py`.

This helper:
- reads the pipeline summary JSON
- derives the stable release tag/name/URL
- derives the expected release-asset filenames from `artifact_contract.published_artifacts`
- writes release notes that record:
  - artifact set id
  - generated timestamp
  - teams
  - `pbp-analysis` ref
  - `pbp-parser` ref
  - verification counts
  - workflow run URL
- writes workflow outputs for the publish step

I kept this logic out of the YAML so the release naming and notes contract is testable.

### Documentation
Updated:
- `docs/published-artifact-contract.md`
- `docs/demo-runbook.md`
- `README.md`

These now make the publication target explicit, document the retrieval URLs, and clarify the split between:
- GitHub release assets = canonical current season set
- GitHub Actions artifacts = per-run operator/debug provenance
- `yr-data-api/data/pbp_stats_bundle.json` = local handoff convenience only

## Contract Details
The published contract itself is unchanged at the file/schema level. The change here is the **publication location**.

The release is intentionally a rolling season target:
- each successful publishable run replaces the current season assets in place
- release notes record the exact refs and artifact set id for the current publish
- per-run Actions artifacts remain the historical provenance trail

This keeps retrieval simple for consumers while preserving run history elsewhere.

## Validation
Ran locally:

```bash
PYTHONPATH=. /Users/victorres/projects2/pbp/.venv/bin/python -m pytest -q \
  tests/test_published_release.py \
  tests/test_pipeline_summary_contract.py \
  tests/test_game_prep_loader_artifacts.py \
  tests/test_scoring_zones_issue_158.py
```

Result: `10 passed`

Also validated:
- `PYTHONPATH=. /Users/victorres/projects2/pbp/.venv/bin/python -m compileall scripts/game_prep_brief/published_release.py`
- parsed `.github/workflows/brief-live-refresh.yml` successfully with `yaml.safe_load(...)`

## Follow-on
This sets up the next productionization issues cleanly:
- `#200` can add scheduled runs and notifications against a real publication target
- `#202` can point consumers at the season release assets by default instead of local handoff paths
