### PR TITLE
Schedule live refresh runs and alerts

### DIFF
--- a/.github/workflows/brief-live-refresh.yml
+++ b/.github/workflows/brief-live-refresh.yml
@@ -47,9 +47,12 @@ on:
         required: true
         type: boolean
         default: true
+  schedule:
+    - cron: "17 13 * * *"
 
 permissions:
   contents: write
+  issues: write
 
 concurrency:
   group: brief-live-refresh
@@ -57,6 +60,7 @@ concurrency:
 
 jobs:
   live-refresh:
+    if: github.event_name != 'schedule' || vars.BRIEF_LIVE_REFRESH_SCHEDULE_ENABLED != 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 90
     defaults:
@@ -69,18 +73,57 @@ jobs:
         with:
           path: pbp-analysis
 
+      - name: Resolve run configuration
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TEAM1: ${{ inputs.team1 }}
+          INPUT_TEAM2: ${{ inputs.team2 }}
+          INPUT_SEASON: ${{ inputs.season }}
+          INPUT_LAST_N: ${{ inputs.last_n }}
+          INPUT_BRIEF_FORMAT: ${{ inputs.brief_format }}
+          INPUT_RUN_TESTS: ${{ inputs.run_tests }}
+          INPUT_STRICT_VERIFICATION: ${{ inputs.strict_verification }}
+          INPUT_INCLUDE_ENRICHMENT: ${{ inputs.include_enrichment }}
+          VAR_TEAM1: ${{ vars.BRIEF_LIVE_REFRESH_TEAM1 }}
+          VAR_TEAM2: ${{ vars.BRIEF_LIVE_REFRESH_TEAM2 }}
+          VAR_SEASON: ${{ vars.BRIEF_LIVE_REFRESH_SEASON }}
+          VAR_LAST_N: ${{ vars.BRIEF_LIVE_REFRESH_LAST_N }}
+          VAR_BRIEF_FORMAT: ${{ vars.BRIEF_LIVE_REFRESH_BRIEF_FORMAT }}
+          VAR_RUN_TESTS: ${{ vars.BRIEF_LIVE_REFRESH_RUN_TESTS }}
+          VAR_STRICT_VERIFICATION: ${{ vars.BRIEF_LIVE_REFRESH_STRICT_VERIFICATION }}
+          VAR_INCLUDE_ENRICHMENT: ${{ vars.BRIEF_LIVE_REFRESH_INCLUDE_ENRICHMENT }}
+        run: |
+          python -m scripts.game_prep_brief.live_refresh_ops resolve-config \
+            --event-name "${EVENT_NAME}" \
+            --input-team1 "${INPUT_TEAM1}" \
+            --input-team2 "${INPUT_TEAM2}" \
+            --input-season "${INPUT_SEASON}" \
+            --input-last-n "${INPUT_LAST_N}" \
+            --input-brief-format "${INPUT_BRIEF_FORMAT}" \
+            --input-run-tests "${INPUT_RUN_TESTS}" \
+            --input-strict-verification "${INPUT_STRICT_VERIFICATION}" \
+            --input-include-enrichment "${INPUT_INCLUDE_ENRICHMENT}" \
+            --var-team1 "${VAR_TEAM1}" \
+            --var-team2 "${VAR_TEAM2}" \
+            --var-season "${VAR_SEASON}" \
+            --var-last-n "${VAR_LAST_N}" \
+            --var-brief-format "${VAR_BRIEF_FORMAT}" \
+            --var-run-tests "${VAR_RUN_TESTS}" \
+            --var-strict-verification "${VAR_STRICT_VERIFICATION}" \
+            --var-include-enrichment "${VAR_INCLUDE_ENRICHMENT}"
+
       - name: Resolve artifact paths
         run: |
           root="${RUNNER_TEMP}/brief_live_refresh"
           {
-            echo "PUBLISHED_ROOT=${root}/published/${{ inputs.season }}"
+            echo "PUBLISHED_ROOT=${root}/published/${SEASON}"
             echo "SCRATCH_ROOT=${root}/scratch"
-            echo "BUNDLE_PATH=${root}/published/${{ inputs.season }}/pbp_stats_bundle_${{ inputs.season }}.json"
-            echo "SNAPSHOT_PATH=${root}/published/${{ inputs.season }}/cfbstats_${{ inputs.season }}.json"
-            echo "VERIFICATION_REPORT_PATH=${root}/published/${{ inputs.season }}/cfbstats_verification_${{ inputs.season }}.json"
-            echo "ENRICHMENT_FILE=${root}/scratch/game_prep_enrichment_${{ inputs.season }}.json"
+            echo "BUNDLE_PATH=${root}/published/${SEASON}/pbp_stats_bundle_${SEASON}.json"
+            echo "SNAPSHOT_PATH=${root}/published/${SEASON}/cfbstats_${SEASON}.json"
+            echo "VERIFICATION_REPORT_PATH=${root}/published/${SEASON}/cfbstats_verification_${SEASON}.json"
+            echo "ENRICHMENT_FILE=${root}/scratch/game_prep_enrichment_${SEASON}.json"
             echo "BRIEF_OUTPUT_DIR=${root}/scratch/brief"
-            echo "SUMMARY_JSON=${root}/published/${{ inputs.season }}/game_prep_pipeline_summary_${{ inputs.season }}.json"
+            echo "SUMMARY_JSON=${root}/published/${SEASON}/game_prep_pipeline_summary_${SEASON}.json"
           } >> "${GITHUB_ENV}"
 
       - name: Require main branch
@@ -130,14 +173,6 @@ jobs:
         env:
           PBP_PARSER_ROOT: ${{ github.workspace }}/pbp-parser
           PBP_PIPELINE_PYTHON: python
-          TEAM1: ${{ inputs.team1 }}
-          TEAM2: ${{ inputs.team2 }}
-          SEASON: ${{ inputs.season }}
-          LAST_N: ${{ inputs.last_n }}
-          BRIEF_FORMAT: ${{ inputs.brief_format }}
-          RUN_TESTS: ${{ inputs.run_tests }}
-          STRICT_VERIFICATION: ${{ inputs.strict_verification }}
-          INCLUDE_ENRICHMENT: ${{ inputs.include_enrichment }}
         run: |
           args=(
             "./scripts/refresh-game-prep-pipeline.sh"
@@ -182,9 +217,9 @@ jobs:
           if [[ ! -f "${SUMMARY_JSON}" ]]; then
             {
               echo "publishable=false"
-              echo "release_tag=brief-artifacts-${{ inputs.season }}"
-              echo "release_name=Brief Published Artifacts ${{ inputs.season }}"
-              echo "release_url=https://github.com/${GITHUB_REPOSITORY}/releases/tag/brief-artifacts-${{ inputs.season }}"
+              echo "release_tag=brief-artifacts-${SEASON}"
+              echo "release_name=Brief Published Artifacts ${SEASON}"
+              echo "release_url=https://github.com/${GITHUB_REPOSITORY}/releases/tag/brief-artifacts-${SEASON}"
               echo "release_notes_path="
             } >> "${GITHUB_OUTPUT}"
             exit 0
@@ -194,7 +229,7 @@ jobs:
             --summary-json "${SUMMARY_JSON}" \
             --repo "${GITHUB_REPOSITORY}" \
             --run-url "${RUN_URL}" \
-            --notes-path "${RUNNER_TEMP}/brief_published_artifacts_${{ inputs.season }}.md"
+            --notes-path "${RUNNER_TEMP}/brief_published_artifacts_${SEASON}.md"
 
       - name: Publish season artifact release
         id: publish_release
@@ -225,13 +260,86 @@ jobs:
 
           echo "result=published" >> "${GITHUB_OUTPUT}"
 
+      - name: Prepare scheduled alert
+        if: always() && github.event_name == 'schedule'
+        id: alert
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_CONCLUSION: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RELEASE_URL: ${{ steps.publication.outputs.release_url }}
+        run: |
+          args=(
+            python -m scripts.game_prep_brief.live_refresh_ops prepare-alert
+            --event-name "${EVENT_NAME}"
+            --workflow-conclusion "${WORKFLOW_CONCLUSION}"
+            --run-url "${RUN_URL}"
+            --message-path "${RUNNER_TEMP}/brief_live_refresh_alert.md"
+          )
+
+          if [[ -f "${SUMMARY_JSON}" ]]; then
+            args+=(--summary-json "${SUMMARY_JSON}")
+          fi
+
+          if [[ -n "${RELEASE_URL}" ]]; then
+            args+=(--release-url "${RELEASE_URL}")
+          fi
+
+          "${args[@]}"
+
+      - name: Ensure operator alert issue
+        if: always() && github.event_name == 'schedule' && steps.alert.outputs.should_notify == 'true'
+        id: alert_issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ALERT_ISSUE_TITLE: ${{ steps.alert.outputs.issue_title }}
+        run: |
+          issue_number=$(gh issue list \
+            --repo "${GITHUB_REPOSITORY}" \
+            --state all \
+            --search "\"${ALERT_ISSUE_TITLE}\" in:title" \
+            --limit 1 \
+            --json number \
+            --jq '.[0].number')
+
+          if [[ -z "${issue_number}" || "${issue_number}" == "null" ]]; then
+            issue_number=$(gh issue create \
+              --repo "${GITHUB_REPOSITORY}" \
+              --title "${ALERT_ISSUE_TITLE}" \
+              --label overnight \
+              --label game-brief \
+              --body "Auto-generated operator notification thread for scheduled brief live-refresh failures or non-publishable runs.")
+            issue_number=${issue_number##*/}
+          else
+            state=$(gh issue view "${issue_number}" --repo "${GITHUB_REPOSITORY}" --json state --jq '.state')
+            if [[ "${state}" == "CLOSED" ]]; then
+              gh issue reopen "${issue_number}" --repo "${GITHUB_REPOSITORY}"
+            fi
+          fi
+
+          echo "issue_number=${issue_number}" >> "${GITHUB_OUTPUT}"
+
+      - name: Post scheduled alert
+        if: always() && github.event_name == 'schedule' && steps.alert.outputs.should_notify == 'true'
+        id: post_alert
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment "${{ steps.alert_issue.outputs.issue_number }}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --body-file "${{ steps.alert.outputs.message_path }}"
+
+          echo "result=posted" >> "${GITHUB_OUTPUT}"
+
       - name: Add workflow summary
         if: always()
         env:
+          EVENT_NAME: ${{ github.event_name }}
           RELEASE_TAG: ${{ steps.publication.outputs.release_tag }}
           RELEASE_URL: ${{ steps.publication.outputs.release_url }}
           RELEASE_PUBLISHABLE: ${{ steps.publication.outputs.publishable }}
           RELEASE_RESULT: ${{ steps.publish_release.outputs.result }}
+          ALERT_POSTED: ${{ steps.post_alert.outputs.result }}
         run: |
           python - <<'PY'
           from pathlib import Path
@@ -261,6 +369,7 @@ jobs:
                       f"- Smoke brief passed: `{validation.get('smoke_brief_passed')}`",
                       f"- Publishable: `{(summary.get('artifact_contract') or {}).get('publishable')}`",
                       f"- Published release tag: `{os.environ.get('RELEASE_TAG')}`",
+                      f"- Trigger: `{os.environ.get('EVENT_NAME')}`",
                   ]
               )
               release_result = os.environ.get("RELEASE_RESULT")
@@ -270,6 +379,8 @@ jobs:
                   )
               elif os.environ.get("RELEASE_PUBLISHABLE") == "false":
                   summary_lines.append("- Published release: skipped (run was not publishable)")
+              if os.environ.get("ALERT_POSTED") == "posted":
+                  summary_lines.append("- Scheduled alert: posted to operator issue")
               interrupted = (summary.get("run_state") or {}).get("interrupted_stages") or []
               slow_stages = (summary.get("observability") or {}).get("slow_stages") or []
               if interrupted:

--- a/docs/demo-runbook.md
+++ b/docs/demo-runbook.md
@@ -59,6 +59,7 @@ Workflow behavior:
 - checks out `pbp-analysis` and `pbp-parser`
 - runs `scripts/refresh-game-prep-pipeline.sh` in `live-refresh` mode
 - publishes successful season-core outputs to the GitHub release `brief-artifacts-<season>`
+- runs automatically every day at `13:17 UTC` in addition to manual dispatch
 - uploads:
   - `brief-live-refresh-summary`
   - `brief-live-refresh-smoke-brief`
@@ -89,6 +90,50 @@ The scratch artifact upload contains run-scoped helper outputs:
 - smoke brief outputs
 
 By default the workflow refreshes and requires enrichment. If an operator intentionally disables enrichment, the run still completes, but the summary JSON marks it as non-publishable and the season GitHub release is not updated.
+
+### Scheduled Defaults
+
+The scheduled run uses repository variables when present and falls back to these defaults:
+
+- `BRIEF_LIVE_REFRESH_TEAM1` or `Washington`
+- `BRIEF_LIVE_REFRESH_TEAM2` or `Ohio State`
+- `BRIEF_LIVE_REFRESH_SEASON` or `2025`
+- `BRIEF_LIVE_REFRESH_LAST_N` or `3`
+- `BRIEF_LIVE_REFRESH_BRIEF_FORMAT` or `markdown`
+- `BRIEF_LIVE_REFRESH_RUN_TESTS` or `false`
+- `BRIEF_LIVE_REFRESH_STRICT_VERIFICATION` or `true`
+- `BRIEF_LIVE_REFRESH_INCLUDE_ENRICHMENT` or `true`
+
+The workflow treats `BRIEF_LIVE_REFRESH_SCHEDULE_ENABLED=false` as a pause switch for the scheduled trigger. Manual dispatch remains available even when the schedule is paused.
+
+### Scheduled Failure Notifications
+
+Scheduled runs notify operators only when a run is unhealthy:
+
+- workflow failure
+- non-publishable run
+- verification fail metrics
+- missing required published artifacts
+- missing pipeline summary JSON
+
+Notification channel:
+
+- the workflow maintains a GitHub issue thread titled `Brief Live Refresh Alerts`
+- if the issue does not exist, the workflow creates it with labels `overnight` and `game-brief`
+- each unhealthy scheduled run adds a comment with:
+  - run URL
+  - season and matchup
+  - publishable status
+  - verification counts
+  - interrupted / slow stages
+  - non-publishable reasons
+
+This keeps scheduled operator alerts inside the repo without requiring an external webhook service.
+
+To pause scheduled operations when needed:
+
+- set repository variable `BRIEF_LIVE_REFRESH_SCHEDULE_ENABLED=false`, or
+- disable the workflow in the Actions UI
 
 ### Published Contract
 

--- a/scripts/game_prep_brief/live_refresh_ops.py
+++ b/scripts/game_prep_brief/live_refresh_ops.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+ALERT_ISSUE_TITLE = "Brief Live Refresh Alerts"
+
+DEFAULT_RUN_CONFIG = {
+    "team1": "Washington",
+    "team2": "Ohio State",
+    "season": "2025",
+    "last_n": "3",
+    "brief_format": "markdown",
+    "run_tests": "false",
+    "strict_verification": "true",
+    "include_enrichment": "true",
+}
+
+
+def _normalize_bool_string(value: str | None, default: str) -> str:
+    if value is None or value == "":
+        return default
+    lowered = value.strip().lower()
+    if lowered in {"1", "true", "yes", "on"}:
+        return "true"
+    if lowered in {"0", "false", "no", "off"}:
+        return "false"
+    return default
+
+
+def resolve_run_config(
+    *,
+    event_name: str,
+    input_values: dict[str, str | None],
+    variable_values: dict[str, str | None],
+) -> dict[str, str]:
+    resolved: dict[str, str] = {}
+
+    for key, default in DEFAULT_RUN_CONFIG.items():
+        if event_name == "schedule":
+            source_value = variable_values.get(key)
+        else:
+            source_value = input_values.get(key)
+
+        if key in {"run_tests", "strict_verification", "include_enrichment"}:
+            resolved[key] = _normalize_bool_string(source_value, default)
+        else:
+            resolved[key] = (source_value or default).strip() or default
+
+    return resolved
+
+
+def build_alert_payload(
+    *,
+    event_name: str,
+    workflow_conclusion: str,
+    run_url: str,
+    summary: dict[str, Any] | None,
+    release_url: str | None,
+) -> dict[str, Any]:
+    if event_name != "schedule":
+        return {"should_notify": False}
+
+    if summary is None:
+        body = "\n".join(
+            [
+                "## Scheduled live-refresh alert",
+                "",
+                "- Reason: `missing_pipeline_summary`",
+                f"- Workflow conclusion: `{workflow_conclusion}`",
+                f"- Workflow run: {run_url}",
+                "",
+                "The workflow completed without a readable pipeline summary JSON, so the scheduled run should be treated as failed.",
+            ]
+        )
+        return {
+            "should_notify": True,
+            "body": body + "\n",
+        }
+
+    artifact_contract = summary.get("artifact_contract") or {}
+    validation = summary.get("validation") or {}
+    run_state = summary.get("run_state") or {}
+    observability = summary.get("observability") or {}
+    warnings = summary.get("warnings") or []
+
+    publishable = bool(artifact_contract.get("publishable"))
+    verification_fail_count = validation.get("verification_fail_count", 0)
+    published_complete = bool(artifact_contract.get("published_set_complete"))
+
+    should_notify = (
+        workflow_conclusion != "success"
+        or not publishable
+        or verification_fail_count not in (0, None)
+        or not published_complete
+    )
+    if not should_notify:
+        return {"should_notify": False}
+
+    reason_ids: list[str] = []
+    if workflow_conclusion != "success":
+        reason_ids.append("workflow_failure")
+    if not publishable:
+        reason_ids.append("non_publishable")
+    if verification_fail_count not in (0, None):
+        reason_ids.append("verification_fail_metrics")
+    if not published_complete:
+        reason_ids.append("published_artifacts_incomplete")
+
+    teams = ", ".join(summary.get("teams") or [])
+    slow_stages = ", ".join(observability.get("slow_stages") or []) or "none"
+    interrupted_stages = ", ".join(run_state.get("interrupted_stages") or []) or "none"
+    non_publishable_reasons = ", ".join(artifact_contract.get("non_publishable_reasons") or []) or "none"
+
+    lines = [
+        "## Scheduled live-refresh alert",
+        "",
+        f"- Reason ids: `{', '.join(reason_ids)}`",
+        f"- Workflow conclusion: `{workflow_conclusion}`",
+        f"- Workflow run: {run_url}",
+        f"- Season: `{summary.get('season')}`",
+        f"- Teams: `{teams}`",
+        f"- Artifact set id: `{artifact_contract.get('artifact_set_id')}`",
+        f"- Publishable: `{publishable}`",
+        f"- Published set complete: `{published_complete}`",
+        f"- Non-publishable reasons: `{non_publishable_reasons}`",
+        f"- Verification fails: `{validation.get('verification_fail_count')}`",
+        f"- Verification warnings: `{validation.get('verification_warning_count')}`",
+        f"- Smoke brief passed: `{validation.get('smoke_brief_passed')}`",
+        f"- Enrichment artifact status: `{(summary.get('enrichment_contract') or {}).get('artifact_status')}`",
+        f"- Interrupted stages: `{interrupted_stages}`",
+        f"- Slow stages: `{slow_stages}`",
+    ]
+    if release_url:
+        lines.append(f"- Published release URL: {release_url}")
+    if warnings:
+        lines.extend(
+            [
+                "",
+                "### Pipeline warnings",
+                "",
+                *[f"- {warning}" for warning in warnings],
+            ]
+        )
+
+    return {
+        "should_notify": True,
+        "body": "\n".join(lines) + "\n",
+    }
+
+
+def _write_github_output(outputs: dict[str, str]) -> None:
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if not github_output:
+        return
+
+    with open(github_output, "a", encoding="utf-8") as handle:
+        for key, value in outputs.items():
+            handle.write(f"{key}={value}\n")
+
+
+def _resolve_config_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--event-name", required=True)
+    parser.add_argument("--input-team1")
+    parser.add_argument("--input-team2")
+    parser.add_argument("--input-season")
+    parser.add_argument("--input-last-n")
+    parser.add_argument("--input-brief-format")
+    parser.add_argument("--input-run-tests")
+    parser.add_argument("--input-strict-verification")
+    parser.add_argument("--input-include-enrichment")
+    parser.add_argument("--var-team1")
+    parser.add_argument("--var-team2")
+    parser.add_argument("--var-season")
+    parser.add_argument("--var-last-n")
+    parser.add_argument("--var-brief-format")
+    parser.add_argument("--var-run-tests")
+    parser.add_argument("--var-strict-verification")
+    parser.add_argument("--var-include-enrichment")
+
+
+def _prepare_alert_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--event-name", required=True)
+    parser.add_argument("--workflow-conclusion", required=True)
+    parser.add_argument("--run-url", required=True)
+    parser.add_argument("--summary-json", type=Path)
+    parser.add_argument("--release-url")
+    parser.add_argument("--message-path", required=True, type=Path)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Live refresh workflow helpers.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    resolve_config = subparsers.add_parser("resolve-config")
+    _resolve_config_args(resolve_config)
+
+    prepare_alert = subparsers.add_parser("prepare-alert")
+    _prepare_alert_args(prepare_alert)
+
+    return parser.parse_args()
+
+
+def _run_resolve_config(args: argparse.Namespace) -> int:
+    config = resolve_run_config(
+        event_name=args.event_name,
+        input_values={
+            "team1": args.input_team1,
+            "team2": args.input_team2,
+            "season": args.input_season,
+            "last_n": args.input_last_n,
+            "brief_format": args.input_brief_format,
+            "run_tests": args.input_run_tests,
+            "strict_verification": args.input_strict_verification,
+            "include_enrichment": args.input_include_enrichment,
+        },
+        variable_values={
+            "team1": args.var_team1,
+            "team2": args.var_team2,
+            "season": args.var_season,
+            "last_n": args.var_last_n,
+            "brief_format": args.var_brief_format,
+            "run_tests": args.var_run_tests,
+            "strict_verification": args.var_strict_verification,
+            "include_enrichment": args.var_include_enrichment,
+        },
+    )
+
+    with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as handle:
+        for env_key, value in (
+            ("TEAM1", config["team1"]),
+            ("TEAM2", config["team2"]),
+            ("SEASON", config["season"]),
+            ("LAST_N", config["last_n"]),
+            ("BRIEF_FORMAT", config["brief_format"]),
+            ("RUN_TESTS", config["run_tests"]),
+            ("STRICT_VERIFICATION", config["strict_verification"]),
+            ("INCLUDE_ENRICHMENT", config["include_enrichment"]),
+        ):
+            handle.write(f"{env_key}={value}\n")
+    return 0
+
+
+def _run_prepare_alert(args: argparse.Namespace) -> int:
+    summary = None
+    if args.summary_json and args.summary_json.exists():
+        summary = json.loads(args.summary_json.read_text(encoding="utf-8"))
+
+    payload = build_alert_payload(
+        event_name=args.event_name,
+        workflow_conclusion=args.workflow_conclusion,
+        run_url=args.run_url,
+        summary=summary,
+        release_url=args.release_url,
+    )
+
+    args.message_path.parent.mkdir(parents=True, exist_ok=True)
+    if payload.get("should_notify"):
+        args.message_path.write_text(payload["body"], encoding="utf-8")
+    elif args.message_path.exists():
+        args.message_path.unlink()
+
+    _write_github_output(
+        {
+            "should_notify": "true" if payload.get("should_notify") else "false",
+            "issue_title": ALERT_ISSUE_TITLE,
+            "message_path": str(args.message_path),
+        }
+    )
+    return 0
+
+
+def main() -> int:
+    args = parse_args()
+    if args.command == "resolve-config":
+        return _run_resolve_config(args)
+    if args.command == "prepare-alert":
+        return _run_prepare_alert(args)
+    raise ValueError(f"Unsupported command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_live_refresh_ops.py
+++ b/tests/test_live_refresh_ops.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from scripts.game_prep_brief.live_refresh_ops import build_alert_payload, resolve_run_config
+
+
+def test_resolve_run_config_uses_schedule_repo_defaults() -> None:
+    config = resolve_run_config(
+        event_name="schedule",
+        input_values={
+            "team1": "Manual Team",
+            "team2": "Manual Opponent",
+            "season": "2030",
+            "last_n": "5",
+            "brief_format": "html",
+            "run_tests": "true",
+            "strict_verification": "false",
+            "include_enrichment": "false",
+        },
+        variable_values={
+            "team1": "Washington",
+            "team2": "Ohio State",
+            "season": "2025",
+            "last_n": "3",
+            "brief_format": "markdown",
+            "run_tests": "false",
+            "strict_verification": "true",
+            "include_enrichment": "true",
+        },
+    )
+
+    assert config == {
+        "team1": "Washington",
+        "team2": "Ohio State",
+        "season": "2025",
+        "last_n": "3",
+        "brief_format": "markdown",
+        "run_tests": "false",
+        "strict_verification": "true",
+        "include_enrichment": "true",
+    }
+
+
+def test_resolve_run_config_keeps_manual_dispatch_inputs() -> None:
+    config = resolve_run_config(
+        event_name="workflow_dispatch",
+        input_values={
+            "team1": "Oregon",
+            "team2": "USC",
+            "season": "2026",
+            "last_n": "4",
+            "brief_format": "both",
+            "run_tests": "true",
+            "strict_verification": "false",
+            "include_enrichment": "false",
+        },
+        variable_values={},
+    )
+
+    assert config == {
+        "team1": "Oregon",
+        "team2": "USC",
+        "season": "2026",
+        "last_n": "4",
+        "brief_format": "both",
+        "run_tests": "true",
+        "strict_verification": "false",
+        "include_enrichment": "false",
+    }
+
+
+def test_build_alert_payload_skips_publishable_scheduled_success() -> None:
+    payload = build_alert_payload(
+        event_name="schedule",
+        workflow_conclusion="success",
+        run_url="https://example.com/run",
+        release_url="https://example.com/release",
+        summary={
+            "season": 2025,
+            "teams": ["Washington", "Ohio State"],
+            "artifact_contract": {
+                "artifact_set_id": "artifact-id",
+                "publishable": True,
+                "published_set_complete": True,
+                "non_publishable_reasons": [],
+            },
+            "validation": {
+                "verification_fail_count": 0,
+                "verification_warning_count": 0,
+                "smoke_brief_passed": True,
+            },
+            "enrichment_contract": {"artifact_status": "validated"},
+            "run_state": {"interrupted_stages": []},
+            "observability": {"slow_stages": []},
+            "warnings": [],
+        },
+    )
+
+    assert payload == {"should_notify": False}
+
+
+def test_build_alert_payload_formats_non_publishable_schedule_failure() -> None:
+    payload = build_alert_payload(
+        event_name="schedule",
+        workflow_conclusion="failure",
+        run_url="https://example.com/run",
+        release_url="https://example.com/release",
+        summary={
+            "season": 2025,
+            "teams": ["Washington", "Ohio State"],
+            "artifact_contract": {
+                "artifact_set_id": "artifact-id",
+                "publishable": False,
+                "published_set_complete": False,
+                "non_publishable_reasons": ["verification_fail_metrics", "enrichment_disabled"],
+            },
+            "validation": {
+                "verification_fail_count": 2,
+                "verification_warning_count": 1,
+                "smoke_brief_passed": False,
+            },
+            "enrichment_contract": {"artifact_status": "disabled"},
+            "run_state": {"interrupted_stages": ["cfbstats_snapshot"]},
+            "observability": {"slow_stages": ["cfbstats_snapshot"]},
+            "warnings": ["[warn] cfbstats_snapshot exceeded expected duration budget (1200s); waiting for completion"],
+        },
+    )
+
+    assert payload["should_notify"] is True
+    assert "workflow_failure" in payload["body"]
+    assert "non_publishable" in payload["body"]
+    assert "verification_fail_metrics" in payload["body"]
+    assert "published_artifacts_incomplete" in payload["body"]
+    assert "artifact-id" in payload["body"]
+    assert "https://example.com/run" in payload["body"]
+    assert "https://example.com/release" in payload["body"]
+    assert "cfbstats_snapshot" in payload["body"]
+    assert "enrichment_disabled" in payload["body"]
+
+
+def test_build_alert_payload_notifies_when_summary_missing() -> None:
+    payload = build_alert_payload(
+        event_name="schedule",
+        workflow_conclusion="failure",
+        run_url="https://example.com/run",
+        release_url=None,
+        summary=None,
+    )
+
+    assert payload["should_notify"] is True
+    assert "missing_pipeline_summary" in payload["body"]


### PR DESCRIPTION
## Summary
Implements `#200` by turning the live-refresh workflow into an operator-run schedule with explicit notification behavior for unhealthy scheduled runs.

After this change:
- `Brief Live Refresh` can run on a daily schedule as well as manual dispatch
- scheduled runs resolve their own default matchup/season/config without manual inputs
- operators can pause the schedule without removing the workflow
- unhealthy scheduled runs post to a dedicated GitHub issue thread inside the repo

## What Changed
### 1. Scheduled trigger
Updated `.github/workflows/brief-live-refresh.yml` to add a daily schedule:
- cron: `17 13 * * *`
- cadence: once per day at `13:17 UTC`

The workflow still supports `workflow_dispatch` unchanged.

### 2. Scheduled run configuration
Added `scripts/game_prep_brief/live_refresh_ops.py` with a `resolve-config` helper so scheduled runs do not depend on `workflow_dispatch` inputs.

The schedule resolves config from repository variables when present, with these defaults:
- `TEAM1`: `Washington`
- `TEAM2`: `Ohio State`
- `SEASON`: `2025`
- `LAST_N`: `3`
- `BRIEF_FORMAT`: `markdown`
- `RUN_TESTS`: `false`
- `STRICT_VERIFICATION`: `true`
- `INCLUDE_ENRICHMENT`: `true`

Repository variable overrides:
- `BRIEF_LIVE_REFRESH_TEAM1`
- `BRIEF_LIVE_REFRESH_TEAM2`
- `BRIEF_LIVE_REFRESH_SEASON`
- `BRIEF_LIVE_REFRESH_LAST_N`
- `BRIEF_LIVE_REFRESH_BRIEF_FORMAT`
- `BRIEF_LIVE_REFRESH_RUN_TESTS`
- `BRIEF_LIVE_REFRESH_STRICT_VERIFICATION`
- `BRIEF_LIVE_REFRESH_INCLUDE_ENRICHMENT`

I kept this logic in Python rather than shell so the behavior is deterministic and unit-testable.

### 3. Schedule pause switch
Added a job-level gate so operators can pause only the scheduled trigger with:
- `BRIEF_LIVE_REFRESH_SCHEDULE_ENABLED=false`

This does not disable manual dispatch. It only suppresses schedule-triggered runs.

### 4. Failure / non-publishable notifications
I chose a GitHub-native operator channel instead of adding an external webhook dependency in this PR.

Implementation:
- scheduled runs prepare an alert payload via `live_refresh_ops.py prepare-alert`
- alerts fire only when the scheduled run is unhealthy:
  - workflow failure
  - non-publishable run
  - verification fail metrics
  - missing required published artifacts
  - missing pipeline summary JSON
- the workflow ensures a repo issue thread titled `Brief Live Refresh Alerts` exists
- if missing, the workflow creates it with labels:
  - `overnight`
  - `game-brief`
- each unhealthy scheduled run posts a comment to that issue thread

Why this path:
- works immediately with GitHub-native permissions
- creates a durable operator-visible history of unhealthy scheduled runs
- avoids blocking on Slack/Teams/webhook infrastructure before the pipeline is stable

### 5. Workflow summary improvements
The live-refresh workflow summary now also records:
- trigger type (`workflow_dispatch` vs `schedule`)
- whether a scheduled alert was posted
- existing release/publication details from `#199`

## Files
Primary files in this PR:
- `.github/workflows/brief-live-refresh.yml`
- `scripts/game_prep_brief/live_refresh_ops.py`
- `tests/test_live_refresh_ops.py`
- `docs/demo-runbook.md`

## Validation
Ran locally:

```bash
PYTHONPATH=. /Users/victorres/projects2/pbp/.venv/bin/python -m pytest -q \
  tests/test_live_refresh_ops.py \
  tests/test_published_release.py \
  tests/test_pipeline_summary_contract.py \
  tests/test_game_prep_loader_artifacts.py \
  tests/test_scoring_zones_issue_158.py
```

Result: `15 passed`

Also validated:
- parsed `.github/workflows/brief-live-refresh.yml` successfully with `yaml.safe_load(...)`
- exercised the issue-search expression used for the alert thread against the live repo

## Runbook / Operator Contract
`docs/demo-runbook.md` now documents:
- the daily UTC cadence
- repo-variable schedule overrides
- the schedule pause switch
- the `Brief Live Refresh Alerts` issue thread behavior
- how operators disable or pause scheduled runs when needed

## Tradeoff
I intentionally kept notifications GitHub-native in this PR.

That means the “operator channel” is a repository issue thread rather than Slack/Teams/webhook delivery. I think that is the right first production step because it is immediately operable, testable, and does not require more secrets/integration work before the refresh pipeline is stable.

If we want external notifications later, this helper structure makes that straightforward without reworking the schedule or alert classification logic.
