### PR TITLE
Define published artifact freshness policy

### DIFF
--- a/.github/workflows/brief-live-refresh.yml
+++ b/.github/workflows/brief-live-refresh.yml
@@ -217,10 +217,15 @@ jobs:
           if [[ ! -f "${SUMMARY_JSON}" ]]; then
             {
               echo "publishable=false"
-              echo "release_tag=brief-artifacts-${SEASON}"
-              echo "release_name=Brief Published Artifacts ${SEASON}"
-              echo "release_url=https://github.com/${GITHUB_REPOSITORY}/releases/tag/brief-artifacts-${SEASON}"
-              echo "release_notes_path="
+              echo "artifact_set_id=${SEASON}-unknown"
+              echo "rolling_release_tag=brief-artifacts-${SEASON}"
+              echo "rolling_release_name=Brief Published Artifacts ${SEASON}"
+              echo "rolling_release_url=https://github.com/${GITHUB_REPOSITORY}/releases/tag/brief-artifacts-${SEASON}"
+              echo "rolling_release_notes_path="
+              echo "archive_release_tag="
+              echo "archive_release_name="
+              echo "archive_release_url="
+              echo "archive_release_notes_path="
             } >> "${GITHUB_OUTPUT}"
             exit 0
           fi
@@ -229,17 +234,47 @@ jobs:
             --summary-json "${SUMMARY_JSON}" \
             --repo "${GITHUB_REPOSITORY}" \
             --run-url "${RUN_URL}" \
-            --notes-path "${RUNNER_TEMP}/brief_published_artifacts_${SEASON}.md"
+            --rolling-notes-path "${RUNNER_TEMP}/brief_published_artifacts_${SEASON}.md" \
+            --archive-notes-path "${RUNNER_TEMP}/brief_published_artifacts_archive_${SEASON}.md"
 
-      - name: Publish season artifact release
-        id: publish_release
+      - name: Publish rolling last-known-good release
+        id: publish_rolling_release
         if: success() && steps.publication.outputs.publishable == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          tag="${{ steps.publication.outputs.release_tag }}"
-          name="${{ steps.publication.outputs.release_name }}"
-          notes="${{ steps.publication.outputs.release_notes_path }}"
+          tag="${{ steps.publication.outputs.rolling_release_tag }}"
+          name="${{ steps.publication.outputs.rolling_release_name }}"
+          notes="${{ steps.publication.outputs.rolling_release_notes_path }}"
+
+          if gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            gh release edit "${tag}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --title "${name}" \
+              --notes-file "${notes}"
+          else
+            gh release create "${tag}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --title "${name}" \
+              --notes-file "${notes}" \
+              --target "${GITHUB_SHA}"
+          fi
+
+          gh release upload "${tag}" "${PUBLISHED_ROOT}"/* \
+            --repo "${GITHUB_REPOSITORY}" \
+            --clobber
+
+          echo "result=published" >> "${GITHUB_OUTPUT}"
+
+      - name: Publish archived artifact-set release
+        id: publish_archive_release
+        if: success() && steps.publication.outputs.publishable == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${{ steps.publication.outputs.archive_release_tag }}"
+          name="${{ steps.publication.outputs.archive_release_name }}"
+          notes="${{ steps.publication.outputs.archive_release_notes_path }}"
 
           if gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
             gh release edit "${tag}" \
@@ -267,7 +302,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           WORKFLOW_CONCLUSION: ${{ job.status }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          RELEASE_URL: ${{ steps.publication.outputs.release_url }}
+          RELEASE_URL: ${{ steps.publication.outputs.rolling_release_url }}
         run: |
           args=(
             python -m scripts.game_prep_brief.live_refresh_ops prepare-alert
@@ -335,10 +370,13 @@ jobs:
         if: always()
         env:
           EVENT_NAME: ${{ github.event_name }}
-          RELEASE_TAG: ${{ steps.publication.outputs.release_tag }}
-          RELEASE_URL: ${{ steps.publication.outputs.release_url }}
+          ROLLING_RELEASE_TAG: ${{ steps.publication.outputs.rolling_release_tag }}
+          ROLLING_RELEASE_URL: ${{ steps.publication.outputs.rolling_release_url }}
+          ARCHIVE_RELEASE_TAG: ${{ steps.publication.outputs.archive_release_tag }}
+          ARCHIVE_RELEASE_URL: ${{ steps.publication.outputs.archive_release_url }}
           RELEASE_PUBLISHABLE: ${{ steps.publication.outputs.publishable }}
-          RELEASE_RESULT: ${{ steps.publish_release.outputs.result }}
+          ROLLING_RELEASE_RESULT: ${{ steps.publish_rolling_release.outputs.result }}
+          ARCHIVE_RELEASE_RESULT: ${{ steps.publish_archive_release.outputs.result }}
           ALERT_POSTED: ${{ steps.post_alert.outputs.result }}
         run: |
           python - <<'PY'
@@ -368,14 +406,20 @@ jobs:
                       f"- Verification warnings: `{validation.get('verification_warning_count')}`",
                       f"- Smoke brief passed: `{validation.get('smoke_brief_passed')}`",
                       f"- Publishable: `{(summary.get('artifact_contract') or {}).get('publishable')}`",
-                      f"- Published release tag: `{os.environ.get('RELEASE_TAG')}`",
+                      f"- Rolling release tag: `{os.environ.get('ROLLING_RELEASE_TAG')}`",
+                      f"- Archive release tag: `{os.environ.get('ARCHIVE_RELEASE_TAG')}`",
                       f"- Trigger: `{os.environ.get('EVENT_NAME')}`",
                   ]
               )
-              release_result = os.environ.get("RELEASE_RESULT")
-              if release_result == "published":
+              rolling_release_result = os.environ.get("ROLLING_RELEASE_RESULT")
+              archive_release_result = os.environ.get("ARCHIVE_RELEASE_RESULT")
+              if rolling_release_result == "published":
                   summary_lines.append(
-                      f"- Published release URL: {os.environ.get('RELEASE_URL')}"
+                      f"- Rolling release URL: {os.environ.get('ROLLING_RELEASE_URL')}"
+                  )
+              if archive_release_result == "published":
+                  summary_lines.append(
+                      f"- Archive release URL: {os.environ.get('ARCHIVE_RELEASE_URL')}"
                   )
               elif os.environ.get("RELEASE_PUBLISHABLE") == "false":
                   summary_lines.append("- Published release: skipped (run was not publishable)")

--- a/docs/demo-runbook.md
+++ b/docs/demo-runbook.md
@@ -58,7 +58,8 @@ Workflow behavior:
 
 - checks out `pbp-analysis` and `pbp-parser`
 - runs `scripts/refresh-game-prep-pipeline.sh` in `live-refresh` mode
-- publishes successful season-core outputs to the GitHub release `brief-artifacts-<season>`
+- publishes successful season-core outputs to the rolling GitHub release `brief-artifacts-<season>`
+- archives the same publishable set to `brief-artifacts-archive-<artifact_set_id>`
 - runs automatically every day at `13:17 UTC` in addition to manual dispatch
 - uploads:
   - `brief-live-refresh-summary`
@@ -84,12 +85,18 @@ Canonical retrieval path for the current season set:
   - `https://github.com/victorres11/pbp-analysis/releases/download/brief-artifacts-<season>/cfbstats_verification_<season>.json`
   - `https://github.com/victorres11/pbp-analysis/releases/download/brief-artifacts-<season>/game_prep_pipeline_summary_<season>.json`
 
+Archived rollback path for one publishable run:
+
+- release page: `https://github.com/victorres11/pbp-analysis/releases/tag/brief-artifacts-archive-<artifact_set_id>`
+
 The scratch artifact upload contains run-scoped helper outputs:
 
 - enrichment file
 - smoke brief outputs
 
 By default the workflow refreshes and requires enrichment. If an operator intentionally disables enrichment, the run still completes, but the summary JSON marks it as non-publishable and the season GitHub release is not updated.
+
+The rolling season release remains the current last-known-good set when a run fails or is non-publishable. Scheduled failures do not advance consumers to a new artifact set automatically.
 
 ### Scheduled Defaults
 
@@ -142,7 +149,9 @@ The specific role of the `yr-data-api` bundle handoff path is documented in [yr-
 
 Short version:
 
-- published production inputs live under `published/<season>/`
+- published production inputs are retrieved from the rolling release `brief-artifacts-<season>`
+- rolling release `brief-artifacts-<season>` is the current last-known-good published set
+- archive releases `brief-artifacts-archive-<artifact_set_id>` preserve each publishable run for rollback
 - enrichment is a first-class run-scoped artifact, but not part of the published season-core set
 - smoke brief outputs remain scratch validation outputs
 - `artifact_contract` inside the summary JSON is the machine-readable source of truth for whether a run is publishable
@@ -150,6 +159,64 @@ Short version:
 - `enrichment_contract` inside the summary JSON is the machine-readable source of truth for enrichment policy and status
 
 The enrichment-specific contract is documented in [enrichment-artifact-contract.md](./enrichment-artifact-contract.md).
+
+### Freshness and Hold Policy
+
+Freshness is determined from the published pipeline summary asset:
+
+- `fresh`: `generated_at` age `<= 36h`
+- `stale_warning`: `> 36h` and `<= 72h`
+- `stale_critical`: `> 72h`
+
+Consumer policy:
+
+- always keep using the current `brief-artifacts-<season>` release unless operators explicitly roll back or republish
+- do not follow failed or non-publishable workflow artifacts
+
+Operator policy:
+
+- `stale_warning`: investigate the refresh pipeline, but keep serving the current season release
+- `stale_critical`: either restore the pipeline quickly or intentionally place the season on hold
+- hold procedure: set `BRIEF_LIVE_REFRESH_SCHEDULE_ENABLED=false`
+
+Pause command example:
+
+```bash
+gh variable set BRIEF_LIVE_REFRESH_SCHEDULE_ENABLED \
+  --repo victorres11/pbp-analysis \
+  --body false
+```
+
+### Rollback Procedure
+
+If the rolling release needs to be backed out after a publishable run:
+
+1. Pause the schedule with `BRIEF_LIVE_REFRESH_SCHEDULE_ENABLED=false`
+2. Identify the desired archive release `brief-artifacts-archive-<artifact_set_id>`
+3. Restore that archive release's assets onto the rolling release `brief-artifacts-<season>`
+4. Confirm the rolling release notes and `game_prep_pipeline_summary_<season>.json` now match the restored archive set
+5. Re-enable the schedule when the pipeline is healthy again
+
+The archive release is the supported rollback source. Workflow artifacts are still useful for debugging, but they are not the intended rollback mechanism.
+
+CLI rollback example:
+
+```bash
+ARCHIVE_TAG="brief-artifacts-archive-<artifact_set_id>"
+ROLLING_TAG="brief-artifacts-<season>"
+TMP_DIR=$(mktemp -d)
+
+gh release download "${ARCHIVE_TAG}" \
+  --repo victorres11/pbp-analysis \
+  --dir "${TMP_DIR}"
+
+gh release upload "${ROLLING_TAG}" \
+  "${TMP_DIR}"/* \
+  --repo victorres11/pbp-analysis \
+  --clobber
+```
+
+After uploading, update the rolling release notes so they reflect the restored archive release metadata before re-enabling the schedule.
 
 ### Offline Validate
 

--- a/docs/published-artifact-contract.md
+++ b/docs/published-artifact-contract.md
@@ -20,13 +20,22 @@ The canonical publication target is a season-scoped GitHub release in `victorres
 
 - release tag: `brief-artifacts-<season>`
 - release title: `Brief Published Artifacts <season>`
+- role: rolling current last-known-good pointer for that season
+
+Each publishable run also creates an immutable archive release:
+
+- release tag: `brief-artifacts-archive-<artifact_set_id>`
+- release title: `Brief Published Artifacts Archive <season> <artifact_set_id>`
+- role: rollback and historical inspection target for one publishable artifact set
 
 For example, the 2025 season core set is published at:
 
 - release page: `https://github.com/victorres11/pbp-analysis/releases/tag/brief-artifacts-2025`
 - direct asset base: `https://github.com/victorres11/pbp-analysis/releases/download/brief-artifacts-2025/`
 
-This release is a rolling target. Each successful publishable live-refresh run updates the assets in place for that season. Operators should treat the current assets on that release as the authoritative published set.
+The season release is a rolling target. Each successful publishable live-refresh run updates the assets in place for that season. Operators and consumers should treat the current assets on that release as the authoritative last-known-good published set.
+
+Archive releases do not replace the rolling release. They preserve each publishable run so operators can inspect or restore a prior artifact set if a later publishable run needs to be backed out.
 
 ## Published Artifact Set
 
@@ -81,6 +90,8 @@ A run is considered `publishable` only when all of the following are true:
 
 Only publishable runs update the season GitHub release. Non-publishable runs still upload workflow artifacts for debugging, but they do not mutate the canonical published release.
 
+That means failed or non-publishable refreshes leave the existing season release in place as the last-known-good artifact set.
+
 The summary JSON records this under:
 
 - `artifact_contract.artifact_set_id`
@@ -95,6 +106,8 @@ Downstream consumers should:
 - resolve stable production inputs from the `brief-artifacts-<season>` GitHub release
 - use `artifact_contract.published_artifacts` to discover the logical artifact names and expected relative paths
 - ignore `artifact_contract.scratch_artifacts` for production consumption
+
+Consumers should not follow workflow artifacts from failed or non-publishable runs. If the latest refresh is unhealthy, they should continue using the current `brief-artifacts-<season>` release until a new publishable run replaces it.
 
 Consumers that need direct download URLs can combine the release tag with the published filenames:
 
@@ -112,6 +125,56 @@ If a consumer needs to distinguish a scratch/local run from a publishable run, i
 - `artifact_contract.publishable`
 - `artifact_contract.non_publishable_reasons`
 
+## Freshness Policy
+
+Freshness is evaluated from the published pipeline summary asset:
+
+- file: `game_prep_pipeline_summary_<season>.json`
+- field: `generated_at`
+
+Default thresholds:
+
+- `fresh`: published summary age is `<= 36h`
+- `stale_warning`: published summary age is `> 36h` and `<= 72h`
+- `stale_critical`: published summary age is `> 72h`
+
+Expected operator/consumer behavior:
+
+- `fresh`
+  - consumers use the current rolling season release normally
+- `stale_warning`
+  - consumers still use the current rolling season release
+  - operators investigate why a new publishable run has not replaced it
+- `stale_critical`
+  - consumers still use the current rolling season release because it remains the last-known-good set
+  - operators should either restore the refresh pipeline or intentionally place the season on hold
+
+This policy is intentionally conservative: freshness warnings do not cause consumers to switch away from the current last-known-good set automatically.
+
+## Hold and Rollback Policy
+
+### Hold
+
+If operators need to freeze publication intentionally:
+
+- set repository variable `BRIEF_LIVE_REFRESH_SCHEDULE_ENABLED=false`
+- continue serving the current `brief-artifacts-<season>` release
+- investigate or repair upstream data/logic before re-enabling the schedule
+
+Manual dispatch remains available while the schedule is paused.
+
+### Rollback
+
+If a publishable run lands but operators decide the new rolling release should be backed out:
+
+1. Pause the schedule with `BRIEF_LIVE_REFRESH_SCHEDULE_ENABLED=false`
+2. Identify the desired archive release `brief-artifacts-archive-<artifact_set_id>`
+3. Republish that archived asset set back onto the rolling season release `brief-artifacts-<season>`
+4. Confirm the rolling release notes and pipeline summary match the restored artifact set
+5. Re-enable the schedule when the pipeline is healthy again
+
+The archive release exists specifically to make this rollback path actionable without relying on expiring workflow artifacts.
+
 ## Workflow Mapping
 
 The GitHub Actions live-refresh workflow writes artifacts into:
@@ -119,7 +182,10 @@ The GitHub Actions live-refresh workflow writes artifacts into:
 - `published/<season>/...` for the published core set
 - `scratch/...` for run-scoped validation outputs
 
-For publishable runs, the workflow then publishes the `published/<season>/...` contents to the season GitHub release.
+For publishable runs, the workflow publishes the `published/<season>/...` contents to:
+
+- the rolling season release `brief-artifacts-<season>`
+- an immutable archive release `brief-artifacts-archive-<artifact_set_id>`
 
 Workflow artifacts remain useful, but they are not the canonical publication target:
 
@@ -129,5 +195,6 @@ Workflow artifacts remain useful, but they are not the canonical publication tar
 ## Retention and Access
 
 - GitHub release assets should be treated as persistent until intentionally replaced by a newer publishable run for the same season.
+- Archive release assets should be treated as immutable historical snapshots for rollback and inspection.
 - GitHub Actions artifacts remain per-run provenance and follow the repository's workflow artifact retention policy.
 - Read access to the `victorres11/pbp-analysis` repository is sufficient to retrieve the published artifact release assets.

--- a/scripts/game_prep_brief/published_release.py
+++ b/scripts/game_prep_brief/published_release.py
@@ -6,8 +6,15 @@ import os
 from pathlib import Path
 from typing import Any
 
+FRESHNESS_WARNING_HOURS = 36
+FRESHNESS_CRITICAL_HOURS = 72
 
-def _published_asset_entries(summary: dict[str, Any], repo: str, release_tag: str) -> list[dict[str, str]]:
+
+def _published_asset_entries(
+    summary: dict[str, Any],
+    repo: str,
+    release_tag: str,
+) -> list[dict[str, str]]:
     artifact_contract = summary.get("artifact_contract") or {}
     published_artifacts = artifact_contract.get("published_artifacts") or {}
     base_download_url = f"https://github.com/{repo}/releases/download/{release_tag}"
@@ -29,6 +36,24 @@ def _published_asset_entries(summary: dict[str, Any], repo: str, release_tag: st
     return assets
 
 
+def _rolling_release(season: int | str, repo: str) -> dict[str, str]:
+    tag = f"brief-artifacts-{season}"
+    return {
+        "tag": tag,
+        "name": f"Brief Published Artifacts {season}",
+        "url": f"https://github.com/{repo}/releases/tag/{tag}",
+    }
+
+
+def _archive_release(artifact_set_id: str, season: int | str, repo: str) -> dict[str, str]:
+    tag = f"brief-artifacts-archive-{artifact_set_id}"
+    return {
+        "tag": tag,
+        "name": f"Brief Published Artifacts Archive {season} {artifact_set_id}",
+        "url": f"https://github.com/{repo}/releases/tag/{tag}",
+    }
+
+
 def build_release_metadata(
     summary: dict[str, Any],
     *,
@@ -36,49 +61,82 @@ def build_release_metadata(
     run_url: str | None = None,
 ) -> dict[str, Any]:
     season = summary["season"]
-    release_tag = f"brief-artifacts-{season}"
-    release_name = f"Brief Published Artifacts {season}"
-    release_url = f"https://github.com/{repo}/releases/tag/{release_tag}"
-    assets = _published_asset_entries(summary, repo, release_tag)
-
     validation = summary.get("validation") or {}
     git_refs = summary.get("git") or {}
     artifact_contract = summary.get("artifact_contract") or {}
+    artifact_set_id = artifact_contract.get("artifact_set_id") or f"{season}-unversioned"
 
-    notes_lines = [
-        f"# {release_name}",
+    rolling = _rolling_release(season, repo)
+    archive = _archive_release(artifact_set_id, season, repo)
+    rolling_assets = _published_asset_entries(summary, repo, rolling["tag"])
+    archive_assets = _published_asset_entries(summary, repo, archive["tag"])
+
+    rolling_notes = [
+        f"# {rolling['name']}",
         "",
         f"This release is the rolling canonical published artifact set for the {season} season.",
+        "It should be treated as the current last-known-good published set for downstream consumers.",
         "Each successful publishable live-refresh run overwrites these release assets in place.",
         "",
-        f"- Artifact set id: `{artifact_contract.get('artifact_set_id')}`",
+        f"- Artifact set id: `{artifact_set_id}`",
         f"- Generated at: `{summary.get('generated_at')}`",
         f"- Teams: `{', '.join(summary.get('teams') or [])}`",
         f"- pbp-analysis ref: `{git_refs.get('pbp_analysis_ref')}`",
         f"- pbp-parser ref: `{git_refs.get('pbp_parser_ref')}`",
         f"- Verification fails: `{validation.get('verification_fail_count')}`",
         f"- Verification warnings: `{validation.get('verification_warning_count')}`",
+        f"- Archived rollback release: {archive['url']}",
+        f"- Freshness warning threshold: `{FRESHNESS_WARNING_HOURS}h`",
+        f"- Freshness critical threshold: `{FRESHNESS_CRITICAL_HOURS}h`",
     ]
     if run_url:
-        notes_lines.append(f"- Workflow run: {run_url}")
-    notes_lines.extend(
-        [
-            "",
-            "## Published Assets",
-        ]
-    )
-    for asset in assets:
-        notes_lines.append(
+        rolling_notes.append(f"- Workflow run: {run_url}")
+    rolling_notes.extend(["", "## Published Assets"])
+    for asset in rolling_assets:
+        rolling_notes.append(
+            f"- `{asset['filename']}` (`{asset['logical_name']}`): {asset['download_url']}"
+        )
+
+    archive_notes = [
+        f"# {archive['name']}",
+        "",
+        "This release preserves one immutable publishable artifact set for rollback and historical inspection.",
+        "It should not be mutated after publication except to repair the same archived artifact set.",
+        "",
+        f"- Artifact set id: `{artifact_set_id}`",
+        f"- Season: `{season}`",
+        f"- Generated at: `{summary.get('generated_at')}`",
+        f"- Teams: `{', '.join(summary.get('teams') or [])}`",
+        f"- Rolling last-known-good release: {rolling['url']}",
+        f"- pbp-analysis ref: `{git_refs.get('pbp_analysis_ref')}`",
+        f"- pbp-parser ref: `{git_refs.get('pbp_parser_ref')}`",
+    ]
+    if run_url:
+        archive_notes.append(f"- Workflow run: {run_url}")
+    archive_notes.extend(["", "## Archived Assets"])
+    for asset in archive_assets:
+        archive_notes.append(
             f"- `{asset['filename']}` (`{asset['logical_name']}`): {asset['download_url']}"
         )
 
     return {
         "publishable": bool(artifact_contract.get("publishable")),
-        "release_tag": release_tag,
-        "release_name": release_name,
-        "release_url": release_url,
-        "assets": assets,
-        "notes": "\n".join(notes_lines) + "\n",
+        "artifact_set_id": artifact_set_id,
+        "freshness_policy": {
+            "warning_hours": FRESHNESS_WARNING_HOURS,
+            "critical_hours": FRESHNESS_CRITICAL_HOURS,
+            "freshness_source": "pipeline_summary.generated_at",
+        },
+        "rolling_release": {
+            **rolling,
+            "assets": rolling_assets,
+            "notes": "\n".join(rolling_notes) + "\n",
+        },
+        "archive_release": {
+            **archive,
+            "assets": archive_assets,
+            "notes": "\n".join(archive_notes) + "\n",
+        },
     }
 
 
@@ -98,7 +156,8 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--summary-json", required=True, type=Path)
     parser.add_argument("--repo", required=True)
-    parser.add_argument("--notes-path", required=True, type=Path)
+    parser.add_argument("--rolling-notes-path", required=True, type=Path)
+    parser.add_argument("--archive-notes-path", required=True, type=Path)
     parser.add_argument("--run-url")
     return parser.parse_args()
 
@@ -108,16 +167,29 @@ def main() -> int:
     summary = json.loads(args.summary_json.read_text(encoding="utf-8"))
     metadata = build_release_metadata(summary, repo=args.repo, run_url=args.run_url)
 
-    args.notes_path.parent.mkdir(parents=True, exist_ok=True)
-    args.notes_path.write_text(metadata["notes"], encoding="utf-8")
+    args.rolling_notes_path.parent.mkdir(parents=True, exist_ok=True)
+    args.archive_notes_path.parent.mkdir(parents=True, exist_ok=True)
+    args.rolling_notes_path.write_text(
+        metadata["rolling_release"]["notes"],
+        encoding="utf-8",
+    )
+    args.archive_notes_path.write_text(
+        metadata["archive_release"]["notes"],
+        encoding="utf-8",
+    )
 
     _write_github_output(
         {
             "publishable": "true" if metadata["publishable"] else "false",
-            "release_tag": metadata["release_tag"],
-            "release_name": metadata["release_name"],
-            "release_url": metadata["release_url"],
-            "release_notes_path": str(args.notes_path),
+            "artifact_set_id": metadata["artifact_set_id"],
+            "rolling_release_tag": metadata["rolling_release"]["tag"],
+            "rolling_release_name": metadata["rolling_release"]["name"],
+            "rolling_release_url": metadata["rolling_release"]["url"],
+            "rolling_release_notes_path": str(args.rolling_notes_path),
+            "archive_release_tag": metadata["archive_release"]["tag"],
+            "archive_release_name": metadata["archive_release"]["name"],
+            "archive_release_url": metadata["archive_release"]["url"],
+            "archive_release_notes_path": str(args.archive_notes_path),
         }
     )
     return 0

--- a/tests/test_published_release.py
+++ b/tests/test_published_release.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
-from scripts.game_prep_brief.published_release import build_release_metadata
+from scripts.game_prep_brief.published_release import (
+    FRESHNESS_CRITICAL_HOURS,
+    FRESHNESS_WARNING_HOURS,
+    build_release_metadata,
+)
 
 
-def test_build_release_metadata_uses_season_scoped_release_assets() -> None:
+def test_build_release_metadata_emits_rolling_and_archive_releases() -> None:
     summary = {
         "season": 2025,
         "generated_at": "2026-03-10T18:23:47.533830+00:00",
@@ -43,12 +47,20 @@ def test_build_release_metadata_uses_season_scoped_release_assets() -> None:
     )
 
     assert metadata["publishable"] is True
-    assert metadata["release_tag"] == "brief-artifacts-2025"
-    assert metadata["release_name"] == "Brief Published Artifacts 2025"
-    assert metadata["release_url"] == (
+    assert metadata["artifact_set_id"] == "2025-20260310T182347Z-9cf24d85d886"
+    assert metadata["freshness_policy"] == {
+        "warning_hours": FRESHNESS_WARNING_HOURS,
+        "critical_hours": FRESHNESS_CRITICAL_HOURS,
+        "freshness_source": "pipeline_summary.generated_at",
+    }
+
+    rolling = metadata["rolling_release"]
+    assert rolling["tag"] == "brief-artifacts-2025"
+    assert rolling["name"] == "Brief Published Artifacts 2025"
+    assert rolling["url"] == (
         "https://github.com/victorres11/pbp-analysis/releases/tag/brief-artifacts-2025"
     )
-    assert metadata["assets"] == [
+    assert rolling["assets"] == [
         {
             "logical_name": "bundle",
             "filename": "pbp_stats_bundle_2025.json",
@@ -82,14 +94,62 @@ def test_build_release_metadata_uses_season_scoped_release_assets() -> None:
             ),
         },
     ]
-    assert "rolling canonical published artifact set" in metadata["notes"]
-    assert "2025-20260310T182347Z-9cf24d85d886" in metadata["notes"]
-    assert "analysis-sha" in metadata["notes"]
-    assert "parser-sha" in metadata["notes"]
-    assert "22916950471" in metadata["notes"]
+    assert "last-known-good" in rolling["notes"]
+    assert "Freshness warning threshold" in rolling["notes"]
+    assert "2025-20260310T182347Z-9cf24d85d886" in rolling["notes"]
+    assert "analysis-sha" in rolling["notes"]
+    assert "parser-sha" in rolling["notes"]
+    assert "22916950471" in rolling["notes"]
+
+    archive = metadata["archive_release"]
+    assert archive["tag"] == "brief-artifacts-archive-2025-20260310T182347Z-9cf24d85d886"
+    assert archive["url"] == (
+        "https://github.com/victorres11/pbp-analysis/releases/tag/"
+        "brief-artifacts-archive-2025-20260310T182347Z-9cf24d85d886"
+    )
+    assert archive["assets"] == [
+        {
+            "logical_name": "bundle",
+            "filename": "pbp_stats_bundle_2025.json",
+            "download_url": (
+                "https://github.com/victorres11/pbp-analysis/releases/download/"
+                "brief-artifacts-archive-2025-20260310T182347Z-9cf24d85d886/"
+                "pbp_stats_bundle_2025.json"
+            ),
+        },
+        {
+            "logical_name": "cfbstats_snapshot",
+            "filename": "cfbstats_2025.json",
+            "download_url": (
+                "https://github.com/victorres11/pbp-analysis/releases/download/"
+                "brief-artifacts-archive-2025-20260310T182347Z-9cf24d85d886/"
+                "cfbstats_2025.json"
+            ),
+        },
+        {
+            "logical_name": "cfbstats_verification_report",
+            "filename": "cfbstats_verification_2025.json",
+            "download_url": (
+                "https://github.com/victorres11/pbp-analysis/releases/download/"
+                "brief-artifacts-archive-2025-20260310T182347Z-9cf24d85d886/"
+                "cfbstats_verification_2025.json"
+            ),
+        },
+        {
+            "logical_name": "pipeline_summary",
+            "filename": "game_prep_pipeline_summary_2025.json",
+            "download_url": (
+                "https://github.com/victorres11/pbp-analysis/releases/download/"
+                "brief-artifacts-archive-2025-20260310T182347Z-9cf24d85d886/"
+                "game_prep_pipeline_summary_2025.json"
+            ),
+        },
+    ]
+    assert "immutable publishable artifact set" in archive["notes"]
+    assert "rolling last-known-good release" in archive["notes"].lower()
 
 
-def test_build_release_metadata_keeps_release_target_stable_for_non_publishable_runs() -> None:
+def test_build_release_metadata_keeps_rolling_target_stable_for_non_publishable_runs() -> None:
     summary = {
         "season": 2025,
         "teams": ["Washington", "Ohio State"],
@@ -103,5 +163,6 @@ def test_build_release_metadata_keeps_release_target_stable_for_non_publishable_
     metadata = build_release_metadata(summary, repo="victorres11/pbp-analysis")
 
     assert metadata["publishable"] is False
-    assert metadata["release_tag"] == "brief-artifacts-2025"
-    assert metadata["release_url"].endswith("/brief-artifacts-2025")
+    assert metadata["rolling_release"]["tag"] == "brief-artifacts-2025"
+    assert metadata["rolling_release"]["url"].endswith("/brief-artifacts-2025")
+    assert metadata["archive_release"]["tag"] == "brief-artifacts-archive-artifact-id"


### PR DESCRIPTION
## Summary
Implements `#201` by defining explicit freshness, hold, rollback, and last-known-good behavior for published brief artifacts.

The key design choice is:
- keep `brief-artifacts-<season>` as the rolling current last-known-good release for consumers
- create an immutable archive release for every publishable `artifact_set_id`

That gives us a concrete rollback source while preserving the simple consumer path introduced in `#199`.

## Policy Decisions
### Last-known-good behavior
The rolling season release remains the canonical consumer target:
- `brief-artifacts-<season>`

Only publishable runs update it. Failed or non-publishable refreshes do not mutate it.

That means consumers should keep using the current rolling release after a failed refresh instead of chasing per-run workflow artifacts.

### Archive / rollback behavior
Each publishable run now also publishes an immutable archive release:
- `brief-artifacts-archive-<artifact_set_id>`

Purpose:
- preserve every publishable artifact set for inspection
- provide a concrete rollback source
- avoid relying on expiring Actions artifacts for rollback

### Freshness thresholds
Freshness is defined from the published pipeline summary asset on the rolling season release:
- source: `game_prep_pipeline_summary_<season>.json`
- field: `generated_at`

Thresholds:
- `fresh`: `<= 36h`
- `stale_warning`: `> 36h` and `<= 72h`
- `stale_critical`: `> 72h`

Behavior:
- consumers still use the rolling release in all three states
- operators investigate at `stale_warning`
- operators either restore the pipeline or intentionally place the season on hold at `stale_critical`

## Implementation
### Workflow
Updated `.github/workflows/brief-live-refresh.yml` so publishable runs now:
- publish the rolling season release `brief-artifacts-<season>`
- publish the immutable archive release `brief-artifacts-archive-<artifact_set_id>`
- report both rolling and archive release identifiers/URLs in the workflow summary

The scheduled alert path continues to reference the rolling season release, which is the consumer-facing last-known-good target.

### Release metadata helper
Updated `scripts/game_prep_brief/published_release.py` to:
- emit rolling release metadata
- emit archive release metadata
- include freshness thresholds in the rolling release notes
- include archive rollback linkage in the rolling release notes
- include rolling-release linkage in the archive notes

I kept this in the helper rather than hardcoding it in YAML so the release semantics stay testable.

### Documentation
Updated:
- `docs/published-artifact-contract.md`
- `docs/demo-runbook.md`

These now define:
- freshness thresholds
- last-known-good semantics
- schedule hold behavior
- rollback procedure
- CLI examples for pausing the schedule and restoring a rolling release from an archive release

## Validation
Ran locally:

```bash
PYTHONPATH=. /Users/victorres/projects2/pbp/.venv/bin/python -m pytest -q \
  tests/test_published_release.py \
  tests/test_live_refresh_ops.py \
  tests/test_pipeline_summary_contract.py \
  tests/test_game_prep_loader_artifacts.py \
  tests/test_scoring_zones_issue_158.py
```

Result: `15 passed`

Also validated:
- `PYTHONPATH=. /Users/victorres/projects2/pbp/.venv/bin/python -m compileall scripts/game_prep_brief/published_release.py`
- parsed `.github/workflows/brief-live-refresh.yml` successfully with `yaml.safe_load(...)`

## Why this shape
I considered a docs-only freshness policy, but that would still leave rollback depending on expiring workflow artifacts or operator memory.

Archiving each publishable release keeps the consumer contract simple:
- one rolling release for normal consumption
- one immutable archive release per publishable run for rollback

That is the minimum additional machinery I think makes the rollback story credible.

## Follow-on
This sets up `#202` and `#203` cleanly:
- `#202` can point consumers at the rolling release by default
- `#203` can read freshness from the rolling release summary and surface the latest status without inventing a new policy layer
