### PR TITLE
Add latest-run status view for brief pipeline

### DIFF
--- a/.github/workflows/brief-live-refresh.yml
+++ b/.github/workflows/brief-live-refresh.yml
@@ -123,6 +123,7 @@ jobs:
             echo "VERIFICATION_REPORT_PATH=${root}/published/${SEASON}/cfbstats_verification_${SEASON}.json"
             echo "ENRICHMENT_FILE=${root}/scratch/game_prep_enrichment_${SEASON}.json"
             echo "BRIEF_OUTPUT_DIR=${root}/scratch/brief"
+            echo "STATUS_VIEW_PATH=${root}/scratch/brief_live_refresh_status.md"
             echo "SUMMARY_JSON=${root}/published/${SEASON}/game_prep_pipeline_summary_${SEASON}.json"
           } >> "${GITHUB_ENV}"
 
@@ -370,6 +371,7 @@ jobs:
         if: always()
         env:
           EVENT_NAME: ${{ github.event_name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           ROLLING_RELEASE_TAG: ${{ steps.publication.outputs.rolling_release_tag }}
           ROLLING_RELEASE_URL: ${{ steps.publication.outputs.rolling_release_url }}
           ARCHIVE_RELEASE_TAG: ${{ steps.publication.outputs.archive_release_tag }}
@@ -379,61 +381,29 @@ jobs:
           ARCHIVE_RELEASE_RESULT: ${{ steps.publish_archive_release.outputs.result }}
           ALERT_POSTED: ${{ steps.post_alert.outputs.result }}
         run: |
-          python - <<'PY'
-          from pathlib import Path
-          import json
-          import os
+          python -m scripts.game_prep_brief.live_refresh_ops render-status-view \
+            --event-name "${EVENT_NAME}" \
+            --workflow-conclusion "${{ job.status }}" \
+            --run-url "${RUN_URL}" \
+            --summary-json "${SUMMARY_JSON}" \
+            --release-publishable "${RELEASE_PUBLISHABLE}" \
+            --rolling-release-url "${ROLLING_RELEASE_URL}" \
+            --archive-release-url "${ARCHIVE_RELEASE_URL}" \
+            --rolling-release-result "${ROLLING_RELEASE_RESULT}" \
+            --archive-release-result "${ARCHIVE_RELEASE_RESULT}" \
+            --alert-posted "${ALERT_POSTED}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --output-path "${STATUS_VIEW_PATH}"
 
-          summary_path = Path(os.environ["SUMMARY_JSON"])
-          summary_lines = ["## Brief Live Refresh"]
-          if not summary_path.exists():
-              summary_lines.append("")
-              summary_lines.append("Pipeline summary JSON was not produced.")
-          else:
-              summary = json.loads(summary_path.read_text(encoding="utf-8"))
-              validation = summary.get("validation") or {}
-              summary_lines.extend(
-                  [
-                      "",
-                      f"- Mode: `{summary.get('mode')}`",
-                      f"- Teams: `{', '.join(summary.get('teams') or [])}`",
-                      f"- Season: `{summary.get('season')}`",
-                      f"- Exit code: `{summary.get('exit_code')}`",
-                      f"- Heartbeat interval: `{(summary.get('observability') or {}).get('heartbeat_interval_seconds')}`s",
-                      f"- Enrichment policy: `{(summary.get('enrichment_contract') or {}).get('policy')}`",
-                      f"- Enrichment artifact status: `{(summary.get('enrichment_contract') or {}).get('artifact_status')}`",
-                      f"- Verification fails: `{validation.get('verification_fail_count')}`",
-                      f"- Verification warnings: `{validation.get('verification_warning_count')}`",
-                      f"- Smoke brief passed: `{validation.get('smoke_brief_passed')}`",
-                      f"- Publishable: `{(summary.get('artifact_contract') or {}).get('publishable')}`",
-                      f"- Rolling release tag: `{os.environ.get('ROLLING_RELEASE_TAG')}`",
-                      f"- Archive release tag: `{os.environ.get('ARCHIVE_RELEASE_TAG')}`",
-                      f"- Trigger: `{os.environ.get('EVENT_NAME')}`",
-                  ]
-              )
-              rolling_release_result = os.environ.get("ROLLING_RELEASE_RESULT")
-              archive_release_result = os.environ.get("ARCHIVE_RELEASE_RESULT")
-              if rolling_release_result == "published":
-                  summary_lines.append(
-                      f"- Rolling release URL: {os.environ.get('ROLLING_RELEASE_URL')}"
-                  )
-              if archive_release_result == "published":
-                  summary_lines.append(
-                      f"- Archive release URL: {os.environ.get('ARCHIVE_RELEASE_URL')}"
-                  )
-              elif os.environ.get("RELEASE_PUBLISHABLE") == "false":
-                  summary_lines.append("- Published release: skipped (run was not publishable)")
-              if os.environ.get("ALERT_POSTED") == "posted":
-                  summary_lines.append("- Scheduled alert: posted to operator issue")
-              interrupted = (summary.get("run_state") or {}).get("interrupted_stages") or []
-              slow_stages = (summary.get("observability") or {}).get("slow_stages") or []
-              if interrupted:
-                  summary_lines.append(f"- Interrupted stages: `{', '.join(interrupted)}`")
-              if slow_stages:
-                  summary_lines.append(f"- Exceeded expected duration: `{', '.join(slow_stages)}`")
-          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as handle:
-              handle.write("\n".join(summary_lines) + "\n")
-          PY
+          cat "${STATUS_VIEW_PATH}" >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload latest-run status view
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: brief-live-refresh-status-view
+          path: ${{ env.STATUS_VIEW_PATH }}
+          if-no-files-found: warn
 
       - name: Upload pipeline summary
         if: always()

--- a/docs/demo-runbook.md
+++ b/docs/demo-runbook.md
@@ -62,10 +62,16 @@ Workflow behavior:
 - archives the same publishable set to `brief-artifacts-archive-<artifact_set_id>`
 - runs automatically every day at `13:17 UTC` in addition to manual dispatch
 - uploads:
+  - `brief-live-refresh-status-view`
   - `brief-live-refresh-summary`
   - `brief-live-refresh-smoke-brief`
   - `brief-live-refresh-published-artifacts`
   - `brief-live-refresh-scratch-artifacts`
+
+The workflow also renders a human-readable latest-run status markdown view from the same summary JSON used by the pipeline contract. Operators can inspect it either:
+
+- directly in the workflow run summary, or
+- by downloading the `brief-live-refresh-status-view` artifact for that run
 
 The published artifact upload contains the season-scoped core set:
 

--- a/scripts/game_prep_brief/live_refresh_ops.py
+++ b/scripts/game_prep_brief/live_refresh_ops.py
@@ -6,6 +6,8 @@ import os
 from pathlib import Path
 from typing import Any
 
+from .published_artifacts import published_artifact_download_url
+
 
 ALERT_ISSUE_TITLE = "Brief Live Refresh Alerts"
 
@@ -19,6 +21,13 @@ DEFAULT_RUN_CONFIG = {
     "strict_verification": "true",
     "include_enrichment": "true",
 }
+
+WORKFLOW_ARTIFACT_NAMES = (
+    "brief-live-refresh-summary",
+    "brief-live-refresh-status-view",
+    "brief-live-refresh-published-artifacts",
+    "brief-live-refresh-scratch-artifacts",
+)
 
 
 def _normalize_bool_string(value: str | None, default: str) -> str:
@@ -153,6 +162,189 @@ def build_alert_payload(
     }
 
 
+def _status_label(
+    *,
+    workflow_conclusion: str,
+    summary: dict[str, Any] | None,
+) -> str:
+    if summary is None:
+        return "missing_summary"
+
+    artifact_contract = summary.get("artifact_contract") or {}
+    validation = summary.get("validation") or {}
+
+    if workflow_conclusion != "success":
+        return "workflow_failure"
+    if not artifact_contract.get("publishable"):
+        return "non_publishable"
+    if validation.get("verification_fail_count") not in (0, None):
+        return "verification_failures"
+    if not artifact_contract.get("published_set_complete"):
+        return "published_set_incomplete"
+    return "healthy"
+
+
+def build_status_view(
+    *,
+    event_name: str,
+    workflow_conclusion: str,
+    run_url: str,
+    summary: dict[str, Any] | None,
+    release_publishable: str | None,
+    rolling_release_url: str | None,
+    archive_release_url: str | None,
+    rolling_release_result: str | None,
+    archive_release_result: str | None,
+    alert_posted: str | None,
+    repo: str,
+) -> str:
+    status = _status_label(workflow_conclusion=workflow_conclusion, summary=summary)
+    lines = [
+        "# Brief Live Refresh Status",
+        "",
+        f"- Overall status: `{status}`",
+        f"- Workflow conclusion: `{workflow_conclusion}`",
+        f"- Workflow run: {run_url}",
+        f"- Trigger: `{event_name}`",
+    ]
+
+    if summary is None:
+        lines.extend(
+            [
+                "",
+                "## Summary",
+                "",
+                "Pipeline summary JSON was not produced for this run.",
+                "Use the workflow run page and uploaded artifacts to inspect the failure.",
+                "",
+                "## Workflow Artifacts",
+                "",
+                *[f"- `{name}`" for name in WORKFLOW_ARTIFACT_NAMES],
+            ]
+        )
+        return "\n".join(lines) + "\n"
+
+    artifact_contract = summary.get("artifact_contract") or {}
+    validation = summary.get("validation") or {}
+    enrichment = summary.get("enrichment_contract") or {}
+    observability = summary.get("observability") or {}
+    run_state = summary.get("run_state") or {}
+    warnings = summary.get("warnings") or []
+    teams = ", ".join(summary.get("teams") or [])
+    artifact_set_id = artifact_contract.get("artifact_set_id") or "unknown"
+
+    lines.extend(
+        [
+            f"- Generated at: `{summary.get('generated_at')}`",
+            f"- Mode: `{summary.get('mode')}`",
+            f"- Season: `{summary.get('season')}`",
+            f"- Teams: `{teams}`",
+            f"- Artifact set id: `{artifact_set_id}`",
+            f"- Exit code: `{summary.get('exit_code')}`",
+        ]
+    )
+
+    lines.extend(
+        [
+            "",
+            "## Validation",
+            "",
+            f"- Parser tests passed: `{validation.get('parser_tests_passed')}`",
+            f"- Analysis tests passed: `{validation.get('analysis_tests_passed')}`",
+            f"- Smoke brief passed: `{validation.get('smoke_brief_passed')}`",
+            f"- Verification fails: `{validation.get('verification_fail_count')}`",
+            f"- Verification warnings: `{validation.get('verification_warning_count')}`",
+            f"- Enrichment policy: `{enrichment.get('policy')}`",
+            f"- Enrichment artifact status: `{enrichment.get('artifact_status')}`",
+        ]
+    )
+    team_statuses = enrichment.get("team_statuses") or {}
+    if team_statuses:
+        lines.append(
+            "- Enrichment team statuses: "
+            + ", ".join(f"`{team}`=`{status}`" for team, status in sorted(team_statuses.items()))
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Publication",
+            "",
+            f"- Publishable: `{artifact_contract.get('publishable')}`",
+            f"- Published set complete: `{artifact_contract.get('published_set_complete')}`",
+        ]
+    )
+    non_publishable_reasons = artifact_contract.get("non_publishable_reasons") or []
+    if non_publishable_reasons:
+        lines.append(
+            "- Non-publishable reasons: " + ", ".join(f"`{reason}`" for reason in non_publishable_reasons)
+        )
+    if rolling_release_url:
+        lines.append(f"- Rolling release: {rolling_release_url}")
+    if archive_release_url and archive_release_result == "published":
+        lines.append(f"- Archive release: {archive_release_url}")
+    if rolling_release_result:
+        lines.append(f"- Rolling release result: `{rolling_release_result}`")
+    if archive_release_result:
+        lines.append(f"- Archive release result: `{archive_release_result}`")
+
+    season = summary.get("season")
+    if artifact_contract.get("publishable") and release_publishable == "true":
+        lines.extend(
+            [
+                "",
+                "### Authoritative Published Assets",
+                "",
+                f"- Summary JSON: {published_artifact_download_url('pipeline_summary', int(season), repo=repo)}",
+                f"- Bundle: {published_artifact_download_url('bundle', int(season), repo=repo)}",
+                f"- CFBStats snapshot: {published_artifact_download_url('cfbstats_snapshot', int(season), repo=repo)}",
+                f"- Verification report: {published_artifact_download_url('cfbstats_verification_report', int(season), repo=repo)}",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "",
+                "### Authoritative Sources",
+                "",
+                "- Latest run summary JSON: workflow artifact `brief-live-refresh-summary` on this run",
+                "- Published last-known-good artifacts remain on the rolling release until a publishable run replaces them",
+            ]
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Runtime",
+            "",
+            f"- Heartbeat interval: `{observability.get('heartbeat_interval_seconds')}`s",
+            f"- Interrupted stages: `{', '.join(run_state.get('interrupted_stages') or []) or 'none'}`",
+            f"- Slow stages: `{', '.join(observability.get('slow_stages') or []) or 'none'}`",
+        ]
+    )
+    if alert_posted == "posted":
+        lines.append("- Scheduled alert: posted to operator issue")
+    if warnings:
+        lines.extend(
+            [
+                "",
+                "## Warnings",
+                "",
+                *[f"- {warning}" for warning in warnings],
+            ]
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Workflow Artifacts",
+            "",
+            *[f"- `{name}`" for name in WORKFLOW_ARTIFACT_NAMES],
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
 def _write_github_output(outputs: dict[str, str]) -> None:
     github_output = os.environ.get("GITHUB_OUTPUT")
     if not github_output:
@@ -192,6 +384,21 @@ def _prepare_alert_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--message-path", required=True, type=Path)
 
 
+def _render_status_view_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--event-name", required=True)
+    parser.add_argument("--workflow-conclusion", required=True)
+    parser.add_argument("--run-url", required=True)
+    parser.add_argument("--summary-json", type=Path)
+    parser.add_argument("--release-publishable")
+    parser.add_argument("--rolling-release-url")
+    parser.add_argument("--archive-release-url")
+    parser.add_argument("--rolling-release-result")
+    parser.add_argument("--archive-release-result")
+    parser.add_argument("--alert-posted")
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--output-path", required=True, type=Path)
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Live refresh workflow helpers.")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -201,6 +408,9 @@ def parse_args() -> argparse.Namespace:
 
     prepare_alert = subparsers.add_parser("prepare-alert")
     _prepare_alert_args(prepare_alert)
+
+    render_status_view = subparsers.add_parser("render-status-view")
+    _render_status_view_args(render_status_view)
 
     return parser.parse_args()
 
@@ -274,12 +484,38 @@ def _run_prepare_alert(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_render_status_view(args: argparse.Namespace) -> int:
+    summary = None
+    if args.summary_json and args.summary_json.exists():
+        summary = json.loads(args.summary_json.read_text(encoding="utf-8"))
+
+    status_markdown = build_status_view(
+        event_name=args.event_name,
+        workflow_conclusion=args.workflow_conclusion,
+        run_url=args.run_url,
+        summary=summary,
+        release_publishable=args.release_publishable,
+        rolling_release_url=args.rolling_release_url,
+        archive_release_url=args.archive_release_url,
+        rolling_release_result=args.rolling_release_result,
+        archive_release_result=args.archive_release_result,
+        alert_posted=args.alert_posted,
+        repo=args.repo,
+    )
+    args.output_path.parent.mkdir(parents=True, exist_ok=True)
+    args.output_path.write_text(status_markdown, encoding="utf-8")
+    _write_github_output({"status_view_path": str(args.output_path)})
+    return 0
+
+
 def main() -> int:
     args = parse_args()
     if args.command == "resolve-config":
         return _run_resolve_config(args)
     if args.command == "prepare-alert":
         return _run_prepare_alert(args)
+    if args.command == "render-status-view":
+        return _run_render_status_view(args)
     raise ValueError(f"Unsupported command: {args.command}")
 
 

--- a/tests/test_live_refresh_ops.py
+++ b/tests/test_live_refresh_ops.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from scripts.game_prep_brief.live_refresh_ops import build_alert_payload, resolve_run_config
+from scripts.game_prep_brief.live_refresh_ops import (
+    build_alert_payload,
+    build_status_view,
+    resolve_run_config,
+)
 
 
 def test_resolve_run_config_uses_schedule_repo_defaults() -> None:
@@ -148,3 +152,75 @@ def test_build_alert_payload_notifies_when_summary_missing() -> None:
 
     assert payload["should_notify"] is True
     assert "missing_pipeline_summary" in payload["body"]
+
+
+def test_build_status_view_formats_publishable_latest_run() -> None:
+    markdown = build_status_view(
+        event_name="workflow_dispatch",
+        workflow_conclusion="success",
+        run_url="https://example.com/run",
+        summary={
+            "mode": "live-refresh",
+            "season": 2025,
+            "teams": ["Washington", "Ohio State"],
+            "generated_at": "2026-03-10T20:00:00+00:00",
+            "exit_code": 0,
+            "artifact_contract": {
+                "artifact_set_id": "artifact-id",
+                "publishable": True,
+                "published_set_complete": True,
+                "non_publishable_reasons": [],
+            },
+            "validation": {
+                "parser_tests_passed": True,
+                "analysis_tests_passed": True,
+                "verification_fail_count": 0,
+                "verification_warning_count": 1,
+                "smoke_brief_passed": True,
+            },
+            "enrichment_contract": {
+                "policy": "required",
+                "artifact_status": "validated",
+                "team_statuses": {"washington": "ok", "ohio-state": "ok"},
+            },
+            "run_state": {"interrupted_stages": []},
+            "observability": {"heartbeat_interval_seconds": 60, "slow_stages": []},
+            "warnings": [],
+        },
+        release_publishable="true",
+        rolling_release_url="https://example.com/release",
+        archive_release_url="https://example.com/archive",
+        rolling_release_result="published",
+        archive_release_result="published",
+        alert_posted=None,
+        repo="victorres11/pbp-analysis",
+    )
+
+    assert "# Brief Live Refresh Status" in markdown
+    assert "Overall status: `healthy`" in markdown
+    assert "https://example.com/run" in markdown
+    assert "artifact-id" in markdown
+    assert "Authoritative Published Assets" in markdown
+    assert "game_prep_pipeline_summary_2025.json" in markdown
+    assert "pbp_stats_bundle_2025.json" in markdown
+    assert "brief-live-refresh-status-view" in markdown
+
+
+def test_build_status_view_handles_missing_summary() -> None:
+    markdown = build_status_view(
+        event_name="schedule",
+        workflow_conclusion="failure",
+        run_url="https://example.com/run",
+        summary=None,
+        release_publishable="false",
+        rolling_release_url="https://example.com/release",
+        archive_release_url=None,
+        rolling_release_result=None,
+        archive_release_result=None,
+        alert_posted="posted",
+        repo="victorres11/pbp-analysis",
+    )
+
+    assert "Overall status: `missing_summary`" in markdown
+    assert "Pipeline summary JSON was not produced" in markdown
+    assert "brief-live-refresh-summary" in markdown


### PR DESCRIPTION
Closes #203

## Summary
This adds a lightweight operator-facing latest-run status view for the artifact pipeline without creating a second source of truth.

The implementation reuses the existing pipeline summary JSON and workflow publication context to render a human-readable markdown status document for each live-refresh run. That same markdown is then used for the workflow job summary and uploaded as its own artifact.

## What changed
- Extended `scripts/game_prep_brief/live_refresh_ops.py` with:
  - `build_status_view(...)` to render a markdown latest-run status view from the existing summary JSON and workflow context
  - `render-status-view` CLI subcommand for workflow use
- Updated `.github/workflows/brief-live-refresh.yml` to:
  - write the rendered markdown to `scratch/brief_live_refresh_status.md`
  - append that markdown to `GITHUB_STEP_SUMMARY`
  - upload it as a dedicated artifact named `brief-live-refresh-status-view`
- Updated `docs/demo-runbook.md` to document the new operator inspection path

## Status view contents
The rendered markdown includes:
- overall run status
- workflow conclusion and run URL
- generated timestamp, season, teams, mode, artifact set id, and exit code
- verification counts, smoke result, and enrichment status
- publication state, release URLs, and authoritative artifact links
- interrupted/slow stage signals and pipeline warnings
- workflow artifact names for follow-up inspection

## Why this shape
This stays aligned with the issue scope:
- no new source of truth
- no duplicate status schema
- no new storage layer
- no operator needs to parse raw summary JSON to answer “what happened on the latest run?”

For publishable runs, the status view links directly to the authoritative rolling-release assets.
For non-publishable or failed runs, it points operators back to the workflow run and uploaded artifacts while leaving the current rolling release as the last-known-good source.

## Validation
- `PYTHONPATH=. /Users/victorres/projects2/pbp/.venv/bin/python -m pytest -q tests/test_live_refresh_ops.py tests/test_published_release.py tests/test_pipeline_summary_contract.py tests/test_game_prep_loader_artifacts.py tests/test_scoring_zones_issue_158.py`
  - result: `17 passed`
- `PYTHONPATH=. /Users/victorres/projects2/pbp/.venv/bin/python -m compileall scripts/game_prep_brief`
- YAML parse of `.github/workflows/brief-live-refresh.yml`

## Consumption contract
Operators now have two lightweight ways to inspect the latest run without opening raw JSON:
- the workflow job summary on the live-refresh run page
- the uploaded `brief-live-refresh-status-view` artifact for that run

Both are generated from the same pipeline summary JSON and publication context, so this PR does not fork the pipeline contract.
