### PR TITLE
Use source-aligned POT summaries in brief

### DIFF
--- a/scripts/game_prep_brief/loaders.py
+++ b/scripts/game_prep_brief/loaders.py
@@ -1444,10 +1444,16 @@ def _extract_pbp_stats(team_data: dict) -> dict:
         "color": team_data.get("color", "#888888"),
         "conference": team_data.get("conference", ""),
         "abbr": team_data.get("abbr", ""),
+        "source_points_off_turnovers_for": xml_pot.get("points_off_turnovers", "N/A"),
+        "source_points_off_turnovers_against": xml_pot.get("points_off_turnovers_allowed", "N/A"),
+        "source_post_turnover_drives_for": xml_pot.get("pot_drives", "N/A"),
+        "source_post_turnover_drives_against": xml_pot.get("pot_drives_allowed", "N/A"),
         "last3_turnovers_gained": xml_tov.get("last_n_turnovers_forced", "N/A"),
         "last3_turnovers_lost": xml_tov.get("last_n_turnovers", "N/A"),
         "last3_points_off_turnovers_for": xml_pot.get("last_3_points_off_turnovers", "N/A"),
         "last3_points_off_turnovers_against": xml_pot.get("last_3_points_off_turnovers_allowed", "N/A"),
+        "last3_post_turnover_drives_for": xml_pot.get("last_3_pot_drives", "N/A"),
+        "last3_post_turnover_drives_against": xml_pot.get("last_3_pot_drives_allowed", "N/A"),
         "last3_middle8_points_for": xml_m8.get("last_3_middle_eight_points", "N/A"),
         "last3_middle8_points_against": xml_m8.get("last_3_middle_eight_points_allowed", "N/A"),
         "last3_middle8_points_for_pg": xml_m8.get("last_3_middle_eight_points_pg", "N/A"),
@@ -2223,6 +2229,14 @@ def gather_team_data(
         last_n_stats["middle8_margin"] = int(last_n_stats["middle8_points_for"]) - int(
             last_n_stats["middle8_points_against"]
         )
+    if isinstance(pbp_stats.get("last3_points_off_turnovers_for"), (int, float)):
+        last_n_stats["points_off_turnovers_for"] = int(pbp_stats["last3_points_off_turnovers_for"])
+    if isinstance(pbp_stats.get("last3_points_off_turnovers_against"), (int, float)):
+        last_n_stats["points_off_turnovers_against"] = int(pbp_stats["last3_points_off_turnovers_against"])
+    if isinstance(pbp_stats.get("last3_post_turnover_drives_for"), (int, float)):
+        last_n_stats["post_turnover_drives_for"] = int(pbp_stats["last3_post_turnover_drives_for"])
+    if isinstance(pbp_stats.get("last3_post_turnover_drives_against"), (int, float)):
+        last_n_stats["post_turnover_drives_against"] = int(pbp_stats["last3_post_turnover_drives_against"])
     if isinstance(pbp_stats.get("last3_penalties_pg"), (int, float)):
         last_n_stats["penalties_per_game"] = float(pbp_stats["last3_penalties_pg"])
 

--- a/scripts/game_prep_brief/sections/_sources.py
+++ b/scripts/game_prep_brief/sections/_sources.py
@@ -7,6 +7,7 @@ def _src(label: str) -> str:
 
 
 SRC_PBP = _src("pbp")
+SRC_XML = _src("xml")
 SRC_CFB = _src("cfb")
 SRC_PFF = _src("pff")
 SRC_API = _src("api")

--- a/scripts/game_prep_brief/sections/turnovers.py
+++ b/scripts/game_prep_brief/sections/turnovers.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ._sources import SRC_PBP
+from ._sources import SRC_PBP, SRC_XML
 
 
 def _games(team: dict) -> list[dict]:
@@ -52,7 +52,9 @@ def _avg_pts_after_turnover(games: list[dict]) -> float | None:
     total_pts = _sum(games, "points_off_turnovers_for")
     total_drives = 0
     for g in games:
-        total_drives += len(g.get("post_turnover_drives", []) or [])
+        total_drives += sum(
+            1 for drive in (g.get("post_turnover_drives", []) or []) if drive.get("side") == "team_gained"
+        )
     if not total_drives:
         return None
     return round(total_pts / total_drives, 2)
@@ -63,11 +65,44 @@ def _pg(total: int, games: list[dict]) -> float:
     return round(total / n, 1) if n else 0.0
 
 
+def _source_pot_value(team: dict, key: str) -> int | None:
+    value = ((team.get("stats") or {}).get(key))
+    return int(value) if isinstance(value, (int, float)) else None
+
+
+def _season_pot_summary(team: dict) -> dict[str, int | float | None]:
+    games = _games(team)
+    parser_pts_for = _sum(games, "points_off_turnovers_for")
+    parser_pts_against = _sum(games, "points_off_turnovers_against")
+
+    points_for = _source_pot_value(team, "source_points_off_turnovers_for")
+    points_against = _source_pot_value(team, "source_points_off_turnovers_against")
+    drives_for = _source_pot_value(team, "source_post_turnover_drives_for")
+    drives_against = _source_pot_value(team, "source_post_turnover_drives_against")
+
+    if points_for is None:
+        points_for = parser_pts_for
+    if points_against is None:
+        points_against = parser_pts_against
+
+    avg_points_for = round(points_for / drives_for, 2) if isinstance(drives_for, int) and drives_for > 0 else None
+    return {
+        "points_for": points_for,
+        "points_against": points_against,
+        "drives_for": drives_for,
+        "drives_against": drives_against,
+        "offense_pg": _pg(points_for, games),
+        "defense_pg": _pg(points_against, games),
+        "avg_points_per_drive": avg_points_for if avg_points_for is not None else _avg_pts_after_turnover(games),
+    }
+
+
 def _team_html(team: dict) -> str:
     if not team.get("has_pbp"):
         return f"<div class=\"team-card\"><h3>{team['display_name']}</h3><p><em>No PBP data.</em></p></div>"
 
     games = _games(team)
+    pot = _season_pot_summary(team)
     totals = {
         "gained": _sum(games, "turnovers_gained"),
         "lost": _sum(games, "turnovers_lost"),
@@ -75,18 +110,16 @@ def _team_html(team: dict) -> str:
         "int_lost": _sum(games, "interceptions_lost"),
         "fum_gained": _sum(games, "fumbles_gained"),
         "fum_lost": _sum(games, "fumbles_lost"),
-        "pts_for": _sum(games, "points_off_turnovers_for"),
-        "pts_against": _sum(games, "points_off_turnovers_against"),
+        "pts_for": int(pot["points_for"] or 0),
+        "pts_against": int(pot["points_against"] or 0),
     }
-    # POT: use play-by-play derived values (not pre-baked StatBroadcast
-    # aggregates, which are internally inconsistent with their own play tree).
-    season_off_pg = _pg(totals["pts_for"], games)
-    season_def_pg = _pg(totals["pts_against"], games)
+    season_off_pg = pot["offense_pg"]
+    season_def_pg = pot["defense_pg"]
     margin = team.get("pbp_entry", {}).get("aggregates", {}).get("turnover_margin")
     if not isinstance(margin, (int, float)):
         margin = totals["gained"] - totals["lost"]
     drives_split = _post_turnover_drives(games)
-    avg_pts_post_to = _avg_pts_after_turnover(games)
+    avg_pts_post_to = pot["avg_points_per_drive"]
     avg_pts_text = f"{avg_pts_post_to}" if isinstance(avg_pts_post_to, (int, float)) else "N/A"
 
     def _drives_html_block(label: str, items: list[dict]) -> str:
@@ -174,9 +207,9 @@ def _team_html(team: dict) -> str:
       <div class="block">
         <h4>Points Off Turnovers</h4>
         <ul>
-          <li>Offense (off takeaways): {totals['pts_for']} total ({season_off_pg}/gm){SRC_PBP}</li>
-          <li>Defense (allowed off giveaways): {totals['pts_against']} total ({season_def_pg}/gm){SRC_PBP}</li>
-          <li>Avg Points per Post-TO Drive: {avg_pts_text}{SRC_PBP}</li>
+          <li>Offense (off takeaways): {totals['pts_for']} total ({season_off_pg}/gm){SRC_XML}</li>
+          <li>Defense (allowed off giveaways): {totals['pts_against']} total ({season_def_pg}/gm){SRC_XML}</li>
+          <li>Avg Points per Post-TO Drive: {avg_pts_text}{SRC_XML}</li>
         </ul>
       </div>
       <div class="block">
@@ -191,16 +224,16 @@ def _team_md(team: dict) -> str:
     if not team.get("has_pbp"):
         return f"*{team['display_name']}*\n- Turnovers: N/A"
     games = _games(team)
+    pot = _season_pot_summary(team)
     gained = _sum(games, "turnovers_gained")
     lost = _sum(games, "turnovers_lost")
     margin = team.get("pbp_entry", {}).get("aggregates", {}).get("turnover_margin", "N/A")
     if not isinstance(margin, (int, float)):
         margin = gained - lost
-    pts_for = _sum(games, "points_off_turnovers_for")
-    pts_against = _sum(games, "points_off_turnovers_against")
-    # POT: use play-by-play derived values (see _team_html comment).
-    season_off_pg = _pg(pts_for, games)
-    season_def_pg = _pg(pts_against, games)
+    pts_for = int(pot["points_for"] or 0)
+    pts_against = int(pot["points_against"] or 0)
+    season_off_pg = pot["offense_pg"]
+    season_def_pg = pot["defense_pg"]
     margin_note = ""
     points_note = ""
     if _should_show_last_n(team):

--- a/tests/fixtures/golden/washington_ohio_state_sections.json
+++ b/tests/fixtures/golden/washington_ohio_state_sections.json
@@ -61,12 +61,12 @@
     "*Turnovers*",
     "*Washington*",
     "- Margin: 6 (L3: 4) (Gained 19, Lost 13)",
-    "- Offense Points Off TO: 72 (5.5/gm) (L3: 27 for / 7 against)",
-    "- Defense Points Allowed Off Giveaways: 41 (3.2/gm)",
+    "- Offense Points Off TO: 65 (5.0/gm) (L3: 20 for / 7 against)",
+    "- Defense Points Allowed Off Giveaways: 44 (3.4/gm)",
     "*Ohio State*",
     "- Margin: 3 (L3: -1) (Gained 14, Lost 11)",
-    "- Offense Points Off TO: 66 (4.7/gm) (L3: 7 for / 13 against)",
-    "- Defense Points Allowed Off Giveaways: 23 (1.6/gm)"
+    "- Offense Points Off TO: 80 (5.7/gm) (L3: 7 for / 6 against)",
+    "- Defense Points Allowed Off Giveaways: 16 (1.1/gm)"
   ],
   "penalties": [
     "*Penalties*",

--- a/tests/test_game_prep_loader_artifacts.py
+++ b/tests/test_game_prep_loader_artifacts.py
@@ -1,4 +1,5 @@
 from scripts.game_prep_brief import loaders
+from scripts.game_prep_brief.sections import turnovers
 
 
 def test_convert_xml_bundle_team_backfills_game_rows_from_bundle_stats() -> None:
@@ -43,7 +44,17 @@ def test_convert_xml_bundle_team_backfills_game_rows_from_bundle_stats() -> None
             },
             "points_off_turnovers": {
                 "UW": {"games": 1},
-                "OSU": {"games": 1, "points_off_turnovers": 7, "points_off_turnovers_allowed": 3},
+                "OSU": {
+                    "games": 1,
+                    "points_off_turnovers": 7,
+                    "points_off_turnovers_allowed": 3,
+                    "pot_drives": 2,
+                    "pot_drives_allowed": 1,
+                    "last_3_points_off_turnovers": 11,
+                    "last_3_points_off_turnovers_allowed": 4,
+                    "last_3_pot_drives": 3,
+                    "last_3_pot_drives_allowed": 2,
+                },
             },
             "red_zone": {
                 "UW": {"games": 1},
@@ -123,7 +134,16 @@ def test_gather_team_data_uses_offline_cfbstats_artifacts(
             "cfbstats": {"rankings": {"all": {}, "conf": {}, "nonconf": {}}, "two_point_totals": {}},
             "xml_rollups": {
                 "turnovers": {"turnovers": 1, "turnovers_forced": 2, "interceptions": 1, "fumbles_lost": 0},
-                "points_off_turnovers": {"points_off_turnovers": 7, "points_off_turnovers_allowed": 3},
+                "points_off_turnovers": {
+                    "points_off_turnovers": 7,
+                    "points_off_turnovers_allowed": 3,
+                    "pot_drives": 2,
+                    "pot_drives_allowed": 1,
+                    "last_3_points_off_turnovers": 11,
+                    "last_3_points_off_turnovers_allowed": 4,
+                    "last_3_pot_drives": 3,
+                    "last_3_pot_drives_allowed": 2,
+                },
             },
             "aggregates": {"turnover_margin": 1},
             "bye_weeks": [],
@@ -252,7 +272,84 @@ def test_gather_team_data_uses_offline_cfbstats_artifacts(
     assert team["cfbstats_verification"]["summary"]["match"] == 1
     assert team["cfbstats_verification"]["summary"]["special_case"] == 1
     assert team["cfbstats_verification"]["summary"]["warning"] == 1
+    assert team["stats"]["source_points_off_turnovers_for"] == 7
+    assert team["stats"]["source_post_turnover_drives_for"] == 2
+    assert team["last_n"]["points_off_turnovers_for"] == 11
+    assert team["last_n"]["points_off_turnovers_against"] == 4
+    assert team["last_n"]["post_turnover_drives_for"] == 3
+    assert team["last_n"]["post_turnover_drives_against"] == 2
     turnover_metric = next(metric for metric in team["cfbstats_verification"]["metrics"] if metric["key"] == "turnover_margin")
     assert turnover_metric["status"] == "special_case"
     assert turnover_metric["source"] == 0.0
     assert "Turnover-on-downs definition gap" in turnover_metric["note"]
+
+
+def test_turnovers_section_prefers_source_pot_totals_over_parser_game_sums() -> None:
+    team = {
+        "display_name": "Washington",
+        "has_pbp": True,
+        "stats": {
+            "source_points_off_turnovers_for": 11,
+            "source_points_off_turnovers_against": 4,
+            "source_post_turnover_drives_for": 3,
+            "source_post_turnover_drives_against": 2,
+        },
+        "last_n": {
+            "actual_n": 3,
+            "required_n": 3,
+            "turnover_margin": 2,
+            "turnovers_gained": 4,
+            "turnovers_lost": 2,
+            "points_off_turnovers_for": 9,
+            "points_off_turnovers_against": 3,
+        },
+        "pbp_entry": {
+            "aggregates": {"turnover_margin": 2},
+            "games": [
+                {
+                    "game_number": 1,
+                    "opponent": "OSU",
+                    "turnovers_gained": 2,
+                    "turnovers_lost": 1,
+                    "interceptions_gained": 1,
+                    "interceptions_lost": 1,
+                    "fumbles_gained": 1,
+                    "fumbles_lost": 0,
+                    "points_off_turnovers_for": 7,
+                    "points_off_turnovers_against": 0,
+                    "post_turnover_drives": [],
+                },
+                {
+                    "game_number": 2,
+                    "opponent": "ORE",
+                    "turnovers_gained": 2,
+                    "turnovers_lost": 1,
+                    "interceptions_gained": 1,
+                    "interceptions_lost": 0,
+                    "fumbles_gained": 1,
+                    "fumbles_lost": 1,
+                    "points_off_turnovers_for": 0,
+                    "points_off_turnovers_against": 0,
+                    "post_turnover_drives": [],
+                },
+                {
+                    "game_number": 3,
+                    "opponent": "UCLA",
+                    "turnovers_gained": 0,
+                    "turnovers_lost": 0,
+                    "interceptions_gained": 0,
+                    "interceptions_lost": 0,
+                    "fumbles_gained": 0,
+                    "fumbles_lost": 0,
+                    "points_off_turnovers_for": 0,
+                    "points_off_turnovers_against": 0,
+                    "post_turnover_drives": [],
+                },
+            ],
+        },
+    }
+
+    rendered = turnovers.build(team, team)["md_content"]
+
+    assert "- Offense Points Off TO: 11 (3.7/gm)" in rendered
+    assert "- Defense Points Allowed Off Giveaways: 4 (1.3/gm)" in rendered


### PR DESCRIPTION
## Summary
This resolves the remaining contract ambiguity in `pbp-analysis#166` without forcing an unsafe parser rewrite.

After `pbp-parser #244` and `#245`, the season-wide evidence is clear:
- parser `current_game_row` POT is still better on drive-count parity
- parser `next_drive` POT is materially better on point-total parity
- there is no single parser rule flip that cleanly wins both dimensions season-wide

So this PR makes the brief explicit instead of pretending those semantics are the same:
- season and trend POT point summaries now use the source-aligned XML/StatBroadcast POT rows already embedded in the parser bundle
- recent post-turnover drive detail remains parser-derived from `games[].post_turnover_drives`

That keeps the brief consumer honest while the deeper canonical parser POT contract stays open.

## What changed
### Loader contract
- `scripts/game_prep_brief/loaders.py`
  - exposes source-aligned POT season totals/drive counts on `team["stats"]`
    - `source_points_off_turnovers_for`
    - `source_points_off_turnovers_against`
    - `source_post_turnover_drives_for`
    - `source_post_turnover_drives_against`
  - exposes source-aligned last-3 POT values/drive counts on `team["last_n"]`
    - overrides parser last-3 POT points with `xml_pot.last_3_*`
    - adds `post_turnover_drives_for` / `post_turnover_drives_against`

### Turnover section
- `scripts/game_prep_brief/sections/turnovers.py`
  - season POT totals now prefer source-aligned bundle rows instead of summing parser game-row POT points
  - last-3 POT trend lines now reflect the same source-aligned contract
  - `Avg Points per Post-TO Drive` now prefers source POT points ÷ source POT drives
  - recent “After Takeaway / After Giveaway” drive detail still comes from parser game rows
  - HTML source tags now distinguish these lines with `xml` instead of `pbp`

### Fallback correction
- the old fallback `Avg Points per Post-TO Drive` path divided offensive POT points by **all** post-turnover drives, including defensive ones
- this PR fixes that fallback to count only `team_gained` drives

## Why this contract is better
This is the cleanest consumer-side resolution with the current evidence:
- POT **points** in the brief align to the same source rows used for reconciliation
- post-turnover **drive detail** still comes from the parser-owned bundle game rows
- the brief no longer mixes parser season POT totals with source last-3 POT totals
- we avoid shipping a misleading “canonical parser POT rule” before the parser side has actually earned that claim

## Validation
Focused tests passed:
- `PYTHONPATH=. /Users/victorres/projects2/pbp/.venv/bin/python -m pytest -q tests/test_game_prep_loader_artifacts.py tests/test_game_prep_brief_golden.py`
- `PYTHONPATH=. /Users/victorres/projects2/pbp/.venv/bin/python -m pytest -q tests/test_scoring_zones_issue_158.py tests/test_published_artifact_resolution.py tests/test_game_prep_cli_enrichment.py`

Results:
- `5 passed`
- `9 passed`

Notes on full suite:
- running `pytest -q` from this temporary worktree still hits the pre-existing `generate_data.py` relative-path import issue for `pbp_parser.parse`
- that is unrelated to this PR; the brief-specific test coverage above is green

## Golden-output impact
Washington/Ohio State turnover lines now reflect the source-aligned POT rows from the fixture bundle:
- Washington offense POT: `72 -> 65`
- Washington defense POT allowed: `41 -> 44`
- Ohio State offense POT: `66 -> 80`
- Ohio State defense POT allowed: `23 -> 16`

Those are the values already present in the bundle’s embedded source POT rows, so the brief output is now aligned with the same contract used for POT reconciliation.
