### PR TITLE
Make enrichment provider failures explicit

### DIFF
--- a/docs/enrichment-artifact-contract.md
+++ b/docs/enrichment-artifact-contract.md
@@ -22,6 +22,35 @@ The enrichment artifact is a JSON object keyed by team slug:
     "_status": "ok",
     "_source": "yr-data-api",
     "_fetched_at": "2026-03-09T00:00:00+00:00",
+    "_providers": {
+      "blitz": {
+        "status": "ok",
+        "fields": {
+          "blitz_pct": "31.2%",
+          "blitz_pct_last3": "28.7%"
+        },
+        "reasons": []
+      },
+      "negative_plays": {
+        "status": "ok",
+        "fields": {
+          "negative_plays_pg_api": "6.3",
+          "negative_plays_forced_pg_api": "7.1",
+          "negative_plays_pg_last3_api": "5.7",
+          "negative_plays_forced_pg_last3_api": "7.7"
+        },
+        "reasons": []
+      },
+      "pff": {
+        "status": "partial",
+        "fields": {
+          "pff_missed_tackles_pg": "N/A",
+          "pff_tfl_pg": "N/A",
+          "pff_sacks_pg": "N/A"
+        },
+        "reasons": ["pff_tackling:zero_placeholder_response"]
+      }
+    },
     "blitz_pct": "31.2%",
     "negative_plays_pg_api": 6.3,
     "pff_tfl_pg": 7.1
@@ -34,11 +63,27 @@ Per-team entries may contain any of the enrichment keys currently consumed by th
 - `_status`
   - `ok`: at least one enrichment field has signal
   - `unavailable`: the artifact exists for the team but the fetched values were empty / unavailable
+- `_providers`
+  - provider-level fetch envelope used by the brief renderer for explicit warnings
+  - providers currently include `blitz`, `negative_plays`, and `pff`
+  - each provider carries:
+    - `status`: `ok`, `partial`, or `unavailable`
+    - `fields`: the stored values for that provider's enrichment keys
+    - `reasons`: machine-readable fetch or parsing reasons, if any
 - `_source`
   - `yr-data-api` for refreshed artifacts
   - `artifact` for normalized legacy artifacts that did not carry explicit metadata
 - `_fetched_at`
   - UTC timestamp from the refresh step when available
+
+The top-level `_status` intentionally stays coarse for pipeline gating. It answers
+"does this team have any usable enrichment signal at all?" Provider-level
+partial/unavailable truth lives under `_providers`.
+
+When a live refresh preserves a prior flat value because a provider call failed,
+the provider entry still records the current fetch status and reasons. That lets
+the brief render with the last known value while still surfacing that the latest
+refresh was partial or unavailable.
 
 ## Runtime Policy
 

--- a/scripts/game_prep_brief/loaders.py
+++ b/scripts/game_prep_brief/loaders.py
@@ -69,6 +69,90 @@ ENRICHMENT_KEYS = (
     "pff_tempo_label",
 )
 
+ENRICHMENT_PROVIDER_KEYS = {
+    "blitz": (
+        "blitz_pct",
+        "blitz_pct_last3",
+    ),
+    "negative_plays": (
+        "negative_plays_pg_api",
+        "negative_plays_forced_pg_api",
+        "negative_plays_pg_last3_api",
+        "negative_plays_forced_pg_last3_api",
+    ),
+    "pff": (
+        "pff_plays_offense_pg",
+        "pff_plays_defense_pg",
+        "pff_missed_tackles_pg",
+        "pff_tfl_pg",
+        "pff_sacks_pg",
+        "pff_sacks_allowed_pg",
+        "pff_fmt_total",
+        "pff_fmt_pg",
+        "pff_avg_play_clock",
+        "pff_hurry_up_pct",
+        "pff_tempo_label",
+    ),
+}
+
+
+def _has_enrichment_signal(value: object) -> bool:
+    if value in ("N/A", None, ""):
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    return True
+
+
+def _provider_status_for_values(values: dict, keys: tuple[str, ...]) -> str:
+    present = [key for key in keys if _has_enrichment_signal(values.get(key))]
+    if not present:
+        return "unavailable"
+    if len(present) == len(keys):
+        return "ok"
+    return "partial"
+
+
+def _overall_enrichment_status(payload: dict, providers: dict | None = None) -> str:
+    if isinstance(providers, dict) and providers:
+        for provider_name, keys in ENRICHMENT_PROVIDER_KEYS.items():
+            provider = providers.get(provider_name)
+            if not isinstance(provider, dict):
+                continue
+            fields = provider.get("fields")
+            if isinstance(fields, dict) and any(_has_enrichment_signal(fields.get(key)) for key in keys):
+                return "ok"
+    return "ok" if _enrichment_has_signal(payload) else "unavailable"
+
+
+def _normalize_provider_payload(values: dict, provider_payload: dict | None = None) -> dict:
+    normalized_providers: dict = {}
+    for provider_name, keys in ENRICHMENT_PROVIDER_KEYS.items():
+        raw_provider = provider_payload.get(provider_name) if isinstance(provider_payload, dict) else None
+        normalized_provider = dict(raw_provider) if isinstance(raw_provider, dict) else {}
+
+        raw_fields = normalized_provider.get("fields")
+        provider_fields = dict(raw_fields) if isinstance(raw_fields, dict) else {}
+        normalized_provider["fields"] = {
+            key: values.get(key, provider_fields.get(key, "N/A"))
+            for key in keys
+        }
+
+        status = str(normalized_provider.get("status") or "").strip().lower()
+        if status not in {"ok", "partial", "unavailable"}:
+            status = _provider_status_for_values(normalized_provider["fields"], keys)
+        normalized_provider["status"] = status
+
+        raw_reasons = normalized_provider.get("reasons")
+        if isinstance(raw_reasons, list):
+            normalized_provider["reasons"] = [str(reason).strip() for reason in raw_reasons if str(reason).strip()]
+        else:
+            normalized_provider["reasons"] = []
+
+        normalized_providers[provider_name] = normalized_provider
+    return normalized_providers
+
+
 def _norm_team_name(value: str | None) -> str:
     if not value:
         return ""
@@ -231,23 +315,47 @@ def _candidate_team_ids(team_slug: str, team_name: str | None = None) -> list[st
 
 
 def _fetch_text_from_candidates(candidates: list[str], suffix: str, timeout: int = 8, attempts: int = 3) -> str | None:
+    result = _fetch_text_result_from_candidates(
+        candidates,
+        suffix,
+        timeout=timeout,
+        attempts=attempts,
+    )
+    return result.get("text")
+
+
+def _fetch_text_result_from_candidates(
+    candidates: list[str],
+    suffix: str,
+    timeout: int = 8,
+    attempts: int = 3,
+) -> dict[str, object]:
     if not candidates:
-        return None
+        return {"text": None, "status": "unavailable", "reason": "no_team_candidates", "url": None}
+    last_reason = "empty_response"
+    last_url: str | None = None
     for candidate in candidates:
         encoded = urllib.parse.quote(candidate)
         url = f"{YR_DATA_API_BASE}/yr/{encoded}/{suffix}"
+        last_url = url
         for attempt in range(1, attempts + 1):
             try:
                 req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
                 with urllib.request.urlopen(req, timeout=timeout) as resp:
                     text = (resp.read().decode("utf-8", errors="ignore") or "").strip()
                 if text:
-                    return text
-            except Exception:
+                    return {"text": text, "status": "ok", "reason": None, "url": url}
+                last_reason = f"empty_response via {candidate}"
+            except Exception as exc:
+                last_reason = f"{type(exc).__name__}: {exc}"
                 if attempt < attempts:
                     time.sleep(0.2 * attempt)
                 continue
-    return None
+    print(
+        f"[warn] yr-data-api fetch failed for {suffix}: {last_reason}",
+        file=sys.stderr,
+    )
+    return {"text": None, "status": "unavailable", "reason": last_reason, "url": last_url}
 
 
 def _deep_merge(base: dict, overlay: dict) -> dict:
@@ -1931,32 +2039,52 @@ def _extract_pbp_stats(team_data: dict) -> dict:
     }
 
 
-def _fetch_blitz_stats(team_slug: str, team_name: str | None = None) -> dict:
+def _build_provider_entry(
+    provider_name: str,
+    values: dict,
+    *,
+    reasons: list[str] | None = None,
+) -> dict:
+    keys = ENRICHMENT_PROVIDER_KEYS[provider_name]
+    return {
+        "status": _provider_status_for_values(values, keys),
+        "fields": {key: values.get(key, "N/A") for key in keys},
+        "reasons": [reason for reason in (reasons or []) if reason],
+    }
+
+
+def _fetch_blitz_stats(team_slug: str, team_name: str | None = None) -> tuple[dict, dict]:
     """Fetch blitz season/last3 values from yr-data-api. Returns N/A on failure."""
     if not team_slug and not team_name:
-        return {"blitz_pct": "N/A", "blitz_pct_last3": "N/A"}
+        out = {"blitz_pct": "N/A", "blitz_pct_last3": "N/A"}
+        return out, _build_provider_entry("blitz", out, reasons=["no_team_identifier"])
 
     candidates = _candidate_team_ids(team_slug, team_name)
 
     out = {"blitz_pct": "N/A", "blitz_pct_last3": "N/A"}
+    reasons: list[str] = []
 
     for scope_key, scope in (("blitz_pct", "season"), ("blitz_pct_last3", "last3")):
-        text = _fetch_text_from_candidates(candidates, f"pff/blitz?scope={scope}&format=text")
+        result = _fetch_text_result_from_candidates(candidates, f"pff/blitz?scope={scope}&format=text")
+        text = result.get("text")
         if text:
             out[scope_key] = text
+        else:
+            reasons.append(f"{scope_key}:{result.get('reason') or 'unavailable'}")
 
-    return out
+    return out, _build_provider_entry("blitz", out, reasons=reasons)
 
 
-def _fetch_negative_play_stats(team_slug: str, team_name: str | None = None) -> dict:
+def _fetch_negative_play_stats(team_slug: str, team_name: str | None = None) -> tuple[dict, dict]:
     """Fetch offensive/defensive negative plays (season + last3) from yr-data-api."""
     if not team_slug and not team_name:
-        return {
+        out = {
             "negative_plays_pg_api": "N/A",
             "negative_plays_forced_pg_api": "N/A",
             "negative_plays_pg_last3_api": "N/A",
             "negative_plays_forced_pg_last3_api": "N/A",
         }
+        return out, _build_provider_entry("negative_plays", out, reasons=["no_team_identifier"])
 
     candidates = _candidate_team_ids(team_slug, team_name)
 
@@ -1966,6 +2094,7 @@ def _fetch_negative_play_stats(team_slug: str, team_name: str | None = None) -> 
         "negative_plays_pg_last3_api": "N/A",
         "negative_plays_forced_pg_last3_api": "N/A",
     }
+    reasons: list[str] = []
 
     endpoint_specs = [
         ("negative_plays_pg_api", "pbp/negative-plays?scope=season&format=text"),
@@ -1975,17 +2104,20 @@ def _fetch_negative_play_stats(team_slug: str, team_name: str | None = None) -> 
     ]
 
     for key, suffix in endpoint_specs:
-        text = _fetch_text_from_candidates(candidates, suffix)
+        result = _fetch_text_result_from_candidates(candidates, suffix)
+        text = result.get("text")
         if text:
             out[key] = text
+        else:
+            reasons.append(f"{key}:{result.get('reason') or 'unavailable'}")
 
-    return out
+    return out, _build_provider_entry("negative_plays", out, reasons=reasons)
 
 
-def _fetch_pff_snapshot(team_slug: str, team_name: str | None = None) -> dict:
+def _fetch_pff_snapshot(team_slug: str, team_name: str | None = None) -> tuple[dict, dict]:
     """Fetch compact PFF metrics used in callout blocks."""
     if not team_slug and not team_name:
-        return {
+        out = {
             "pff_plays_offense_pg": "N/A",
             "pff_plays_defense_pg": "N/A",
             "pff_missed_tackles_pg": "N/A",
@@ -1998,6 +2130,7 @@ def _fetch_pff_snapshot(team_slug: str, team_name: str | None = None) -> dict:
             "pff_hurry_up_pct": "N/A",
             "pff_tempo_label": "N/A",
         }
+        return out, _build_provider_entry("pff", out, reasons=["no_team_identifier"])
 
     candidates = _candidate_team_ids(team_slug, team_name)
 
@@ -2014,38 +2147,62 @@ def _fetch_pff_snapshot(team_slug: str, team_name: str | None = None) -> dict:
         "pff_hurry_up_pct": "N/A",
         "pff_tempo_label": "N/A",
     }
+    reasons: list[str] = []
 
-    def _try_fetch(suffix: str) -> str | None:
-        return _fetch_text_from_candidates(candidates, suffix)
+    def _try_fetch(suffix: str) -> dict[str, object]:
+        return _fetch_text_result_from_candidates(candidates, suffix)
 
-    plays = _try_fetch("pff/plays?side=both&format=text")
-    if plays and "," in plays:
-        off, deff = plays.split(",", 1)
+    plays_result = _try_fetch("pff/plays?side=both&format=text")
+    plays = plays_result.get("text")
+    if plays and "," in str(plays):
+        off, deff = str(plays).split(",", 1)
         out["pff_plays_offense_pg"] = off.strip() or "N/A"
         out["pff_plays_defense_pg"] = deff.strip() or "N/A"
+    elif plays:
+        reasons.append("pff_plays:malformed_payload")
+    else:
+        reasons.append(f"pff_plays:{plays_result.get('reason') or 'unavailable'}")
 
-    tackling_pg = _try_fetch("pff/tackling-per-game?format=text")
+    tackling_result = _try_fetch("pff/tackling-per-game?format=text")
+    tackling_pg = tackling_result.get("text")
     if tackling_pg:
-        parts = [p.strip() for p in tackling_pg.split("\t")]
+        parts = [p.strip() for p in str(tackling_pg).split("\t")]
         if len(parts) >= 3:
-            out["pff_missed_tackles_pg"] = parts[0] or "N/A"
-            out["pff_tfl_pg"] = parts[1] or "N/A"
-            out["pff_sacks_pg"] = parts[2] or "N/A"
+            first_three = parts[:3]
+            if all(part in {"0", "0.0", "0.00"} for part in first_three):
+                reasons.append("pff_tackling:zero_placeholder_response")
+            else:
+                out["pff_missed_tackles_pg"] = first_three[0] or "N/A"
+                out["pff_tfl_pg"] = first_three[1] or "N/A"
+                out["pff_sacks_pg"] = first_three[2] or "N/A"
+        else:
+            reasons.append("pff_tackling:malformed_payload")
+    else:
+        reasons.append(f"pff_tackling:{tackling_result.get('reason') or 'unavailable'}")
 
-    sacks_allowed = _try_fetch("pff/sacks-allowed?format=text")
+    sacks_allowed_result = _try_fetch("pff/sacks-allowed?format=text")
+    sacks_allowed = sacks_allowed_result.get("text")
     if sacks_allowed:
-        out["pff_sacks_allowed_pg"] = sacks_allowed.strip()
+        out["pff_sacks_allowed_pg"] = str(sacks_allowed).strip()
+    else:
+        reasons.append(f"pff_sacks_allowed:{sacks_allowed_result.get('reason') or 'unavailable'}")
 
-    fmt = _try_fetch("pff/fmt?format=text")
+    fmt_result = _try_fetch("pff/fmt?format=text")
+    fmt = fmt_result.get("text")
     if fmt:
-        parts = [p.strip() for p in fmt.split("\t")]
+        parts = [p.strip() for p in str(fmt).split("\t")]
         if len(parts) >= 2:
             out["pff_fmt_total"] = parts[0] or "N/A"
             out["pff_fmt_pg"] = parts[1] or "N/A"
+        else:
+            reasons.append("pff_fmt:malformed_payload")
+    else:
+        reasons.append(f"pff_fmt:{fmt_result.get('reason') or 'unavailable'}")
 
-    play_clock = _try_fetch("pff/play-clock?format=text")
+    play_clock_result = _try_fetch("pff/play-clock?format=text")
+    play_clock = play_clock_result.get("text")
     if play_clock:
-        parts = [p.strip() for p in play_clock.split("\t")]
+        parts = [p.strip() for p in str(play_clock).split("\t")]
         if len(parts) >= 1:
             out["pff_avg_play_clock"] = parts[0] or "N/A"
         if len(parts) >= 2:
@@ -2054,6 +2211,7 @@ def _fetch_pff_snapshot(team_slug: str, team_name: str | None = None) -> dict:
                 out["pff_hurry_up_pct"] = f"{hurry_pct}%"
             except (ValueError, TypeError):
                 out["pff_hurry_up_pct"] = "N/A"
+                reasons.append("pff_play_clock:invalid_hurry_up_pct")
         try:
             avg = float(out["pff_avg_play_clock"])
             if avg >= 18:
@@ -2064,20 +2222,34 @@ def _fetch_pff_snapshot(team_slug: str, team_name: str | None = None) -> dict:
                 out["pff_tempo_label"] = "Fast"
         except (ValueError, TypeError):
             out["pff_tempo_label"] = "N/A"
+            reasons.append("pff_play_clock:invalid_avg_play_clock")
+    else:
+        reasons.append(f"pff_play_clock:{play_clock_result.get('reason') or 'unavailable'}")
 
-    return out
+    return out, _build_provider_entry("pff", out, reasons=reasons)
 
 
-def _fetch_live_enrichment(team_slug: str, team_name: str | None = None) -> dict:
-    payload = {}
-    payload.update(_fetch_blitz_stats(team_slug, team_name=team_name))
-    payload.update(_fetch_negative_play_stats(team_slug, team_name=team_name))
-    payload.update(_fetch_pff_snapshot(team_slug, team_name=team_name))
-    return payload
+def _fetch_live_enrichment(team_slug: str, team_name: str | None = None) -> tuple[dict, dict]:
+    payload: dict = {}
+    providers: dict = {}
+
+    blitz_values, blitz_provider = _fetch_blitz_stats(team_slug, team_name=team_name)
+    payload.update(blitz_values)
+    providers["blitz"] = blitz_provider
+
+    negative_values, negative_provider = _fetch_negative_play_stats(team_slug, team_name=team_name)
+    payload.update(negative_values)
+    providers["negative_plays"] = negative_provider
+
+    pff_values, pff_provider = _fetch_pff_snapshot(team_slug, team_name=team_name)
+    payload.update(pff_values)
+    providers["pff"] = pff_provider
+
+    return payload, providers
 
 
 def _enrichment_has_signal(payload: dict) -> bool:
-    return any(payload.get(k) not in ("N/A", None, "") for k in ENRICHMENT_KEYS)
+    return any(_has_enrichment_signal(payload.get(k)) for k in ENRICHMENT_KEYS)
 
 
 def normalize_enrichment_payload(payload: dict) -> dict:
@@ -2088,8 +2260,11 @@ def normalize_enrichment_payload(payload: dict) -> dict:
         if not isinstance(slug, str) or not isinstance(raw, dict):
             continue
         out = dict(raw)
-        if "_status" not in out:
-            out["_status"] = "ok" if _enrichment_has_signal(out) else "unavailable"
+        provider_payload = _normalize_provider_payload(out, out.get("_providers"))
+        out["_providers"] = provider_payload
+        status = str(out.get("_status") or "").strip().lower()
+        if status not in {"ok", "unavailable"}:
+            out["_status"] = _overall_enrichment_status(out, provider_payload)
         if "_source" not in out:
             out["_source"] = "artifact"
         normalized[slug] = out
@@ -2105,13 +2280,13 @@ def validate_enrichment_payload(payload: dict, required_team_slugs: list[str]) -
 
 
 def build_team_enrichment(team_slug: str, team_name: str | None = None) -> dict:
-    data = _fetch_live_enrichment(team_slug, team_name=team_name)
-    has_signal = _enrichment_has_signal(data)
+    data, providers = _fetch_live_enrichment(team_slug, team_name=team_name)
     return {
         **data,
+        "_providers": providers,
         "_fetched_at": datetime.now(timezone.utc).isoformat(),
         "_source": "yr-data-api",
-        "_status": "ok" if has_signal else "unavailable",
+        "_status": _overall_enrichment_status(data, providers),
     }
 
 
@@ -2157,8 +2332,8 @@ def merge_enrichment_payload(existing: dict, refreshed: dict) -> dict:
                     out[key] = prior_value
                     continue
             out[key] = value
-        has_signal = _enrichment_has_signal(out)
-        out["_status"] = "ok" if has_signal else "unavailable"
+        out["_providers"] = _normalize_provider_payload(out, incoming.get("_providers"))
+        out["_status"] = _overall_enrichment_status(out, out.get("_providers"))
         merged[slug] = out
     return merged
 
@@ -2594,7 +2769,12 @@ def gather_team_data(
     if fourth_down_gap:
         parity_gaps.append(fourth_down_gap)
     pbp_stats = _extract_pbp_stats(pbp_entry) if pbp_entry else {}
-    seeded = (enrichment_by_slug or {}).get(school_slug) or {}
+    raw_seeded = (enrichment_by_slug or {}).get(school_slug)
+    seeded = (
+        normalize_enrichment_payload({school_slug: raw_seeded}).get(school_slug, {})
+        if isinstance(raw_seeded, dict)
+        else {}
+    )
     if isinstance(seeded, dict):
         for key in ENRICHMENT_KEYS:
             value = seeded.get(key)
@@ -2725,6 +2905,7 @@ def gather_team_data(
         },
         "full_staff": [],
         "stats": pbp_stats,
+        "enrichment": seeded,
         "last_n": last_n_stats,
         "turnover_reconciliation": turnover_recon,
         "turnover_game_reconciliation": turnover_game_recon,

--- a/scripts/game_prep_brief/renderers/html.py
+++ b/scripts/game_prep_brief/renderers/html.py
@@ -44,6 +44,12 @@ PFF_WARNING_KEYS = (
     "pff_fmt_pg",
 )
 
+PROVIDER_LABELS = {
+    "blitz": "Blitz",
+    "negative_plays": "Negative-play API",
+    "pff": "PFF",
+}
+
 
 def _is_missing(value: object) -> bool:
     if value is None:
@@ -54,12 +60,70 @@ def _is_missing(value: object) -> bool:
     return False
 
 
+def _provider_reason_summary(reasons: object) -> str:
+    if not isinstance(reasons, list):
+        return ""
+    joined = " ".join(str(reason).lower() for reason in reasons if reason)
+    if not joined:
+        return ""
+    if "zero_placeholder_response" in joined:
+        return "placeholder zeros"
+    if "malformed_payload" in joined:
+        return "malformed payload"
+    if "empty_response" in joined:
+        return "empty response"
+    if any(token in joined for token in ("timeout", "timeouterror")):
+        return "timeout"
+    if any(token in joined for token in ("httperror", "urlerror", "forbidden", "unauthorized", "401", "403", "412")):
+        return "fetch error"
+    return ""
+
+
+def _provider_warning_fragments(team: dict) -> list[str]:
+    enrichment = team.get("enrichment")
+    providers = enrichment.get("_providers") if isinstance(enrichment, dict) else None
+    if not isinstance(providers, dict):
+        return []
+
+    fragments: list[str] = []
+    for provider_key, provider in providers.items():
+        if not isinstance(provider, dict):
+            continue
+        status = str(provider.get("status") or "").strip().lower()
+        if status not in {"partial", "unavailable"}:
+            continue
+        label = PROVIDER_LABELS.get(provider_key, provider_key.replace("_", " ").title())
+        reason = _provider_reason_summary(provider.get("reasons"))
+        fragment = f"{label} {status}"
+        if reason:
+            fragment += f" ({reason})"
+        fragments.append(fragment)
+    return fragments
+
+
 def _missing_warning(team1: dict, team2: dict) -> str:
+    provider_impacted: list[str] = []
     impacted: list[str] = []
     for team in (team1, team2):
+        provider_fragments = _provider_warning_fragments(team)
+        if provider_fragments:
+            provider_impacted.append(
+                f"{team.get('display_name', 'Team')} ({', '.join(provider_fragments)})"
+            )
+            continue
         stats = team.get("stats", {})
         if any(_is_missing(stats.get(key)) for key in PFF_WARNING_KEYS):
             impacted.append(team.get("display_name", "Team"))
+    if provider_impacted:
+        suffix = (
+            f" Additional teams with missing enrichment fields: {', '.join(impacted)}."
+            if impacted
+            else ""
+        )
+        return (
+            f"Enrichment snapshot issues: {'; '.join(provider_impacted)}. "
+            f"Some situational/trenches metrics may be stale or unavailable.{suffix}"
+        )
     if not impacted:
         return ""
     teams_text = ", ".join(impacted)

--- a/scripts/game_prep_brief/renderers/markdown.py
+++ b/scripts/game_prep_brief/renderers/markdown.py
@@ -25,6 +25,12 @@ PFF_WARNING_KEYS = (
     "pff_fmt_pg",
 )
 
+PROVIDER_LABELS = {
+    "blitz": "Blitz",
+    "negative_plays": "Negative-play API",
+    "pff": "PFF",
+}
+
 
 def _is_missing(value: object) -> bool:
     if value is None:
@@ -35,12 +41,70 @@ def _is_missing(value: object) -> bool:
     return False
 
 
+def _provider_reason_summary(reasons: object) -> str:
+    if not isinstance(reasons, list):
+        return ""
+    joined = " ".join(str(reason).lower() for reason in reasons if reason)
+    if not joined:
+        return ""
+    if "zero_placeholder_response" in joined:
+        return "placeholder zeros"
+    if "malformed_payload" in joined:
+        return "malformed payload"
+    if "empty_response" in joined:
+        return "empty response"
+    if any(token in joined for token in ("timeout", "timeouterror")):
+        return "timeout"
+    if any(token in joined for token in ("httperror", "urlerror", "forbidden", "unauthorized", "401", "403", "412")):
+        return "fetch error"
+    return ""
+
+
+def _provider_warning_fragments(team: dict) -> list[str]:
+    enrichment = team.get("enrichment")
+    providers = enrichment.get("_providers") if isinstance(enrichment, dict) else None
+    if not isinstance(providers, dict):
+        return []
+
+    fragments: list[str] = []
+    for provider_key, provider in providers.items():
+        if not isinstance(provider, dict):
+            continue
+        status = str(provider.get("status") or "").strip().lower()
+        if status not in {"partial", "unavailable"}:
+            continue
+        label = PROVIDER_LABELS.get(provider_key, provider_key.replace("_", " ").title())
+        reason = _provider_reason_summary(provider.get("reasons"))
+        fragment = f"{label} {status}"
+        if reason:
+            fragment += f" ({reason})"
+        fragments.append(fragment)
+    return fragments
+
+
 def _missing_warning(team1: dict, team2: dict) -> str:
+    provider_impacted: list[str] = []
     impacted: list[str] = []
     for team in (team1, team2):
+        provider_fragments = _provider_warning_fragments(team)
+        if provider_fragments:
+            provider_impacted.append(
+                f"{team.get('display_name', 'Team')} ({', '.join(provider_fragments)})"
+            )
+            continue
         stats = team.get("stats", {})
         if any(_is_missing(stats.get(key)) for key in PFF_WARNING_KEYS):
             impacted.append(team.get("display_name", "Team"))
+    if provider_impacted:
+        fallback = (
+            f" Additional teams with missing enrichment fields: {', '.join(impacted)}."
+            if impacted
+            else ""
+        )
+        return (
+            f"⚠️ Enrichment snapshot issues: {'; '.join(provider_impacted)}. "
+            f"Some situational/trenches fields may be stale or unavailable.{fallback}"
+        )
     if not impacted:
         return ""
     return (

--- a/tests/test_enrichment_provider_contract.py
+++ b/tests/test_enrichment_provider_contract.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.game_prep_brief import loaders
+from scripts.game_prep_brief.renderers import html as html_renderer
+from scripts.game_prep_brief.renderers import markdown as markdown_renderer
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PIPELINE_FIXTURES = ROOT / "tests" / "fixtures" / "pipeline"
+
+
+def test_fetch_pff_snapshot_treats_zero_placeholder_as_partial_provider(monkeypatch) -> None:
+    def _fake_fetch(_candidates: list[str], suffix: str, **_kwargs) -> dict[str, object]:
+        payloads = {
+            "pff/plays?side=both&format=text": "70,68",
+            "pff/tackling-per-game?format=text": "0\t0\t0",
+            "pff/sacks-allowed?format=text": "1.4",
+            "pff/fmt?format=text": "11\t1.2",
+            "pff/play-clock?format=text": "16.8\t0.27",
+        }
+        text = payloads.get(suffix)
+        return {"text": text, "status": "ok" if text else "unavailable", "reason": None, "url": suffix}
+
+    monkeypatch.setattr(loaders, "_fetch_text_result_from_candidates", _fake_fetch)
+
+    values, provider = loaders._fetch_pff_snapshot("washington", team_name="Washington")
+
+    assert values["pff_plays_offense_pg"] == "70"
+    assert values["pff_plays_defense_pg"] == "68"
+    assert values["pff_missed_tackles_pg"] == "N/A"
+    assert values["pff_tfl_pg"] == "N/A"
+    assert values["pff_sacks_pg"] == "N/A"
+    assert values["pff_hurry_up_pct"] == "27.0%"
+    assert provider["status"] == "partial"
+    assert "pff_tackling:zero_placeholder_response" in provider["reasons"]
+
+
+def test_merge_enrichment_payload_preserves_prior_values_and_failure_metadata() -> None:
+    existing = {
+        "washington": {
+            "blitz_pct": "31.2%",
+            "pff_missed_tackles_pg": "4.1",
+            "pff_tfl_pg": "7.2",
+            "pff_sacks_pg": "2.9",
+            "_source": "artifact",
+        }
+    }
+    refreshed = {
+        "washington": {
+            "blitz_pct": "31.2%",
+            "blitz_pct_last3": "29.8%",
+            "pff_missed_tackles_pg": "N/A",
+            "pff_tfl_pg": "N/A",
+            "pff_sacks_pg": "N/A",
+            "_providers": {
+                "blitz": {
+                    "status": "ok",
+                    "fields": {"blitz_pct": "31.2%", "blitz_pct_last3": "29.8%"},
+                    "reasons": [],
+                },
+                "negative_plays": {
+                    "status": "unavailable",
+                    "fields": {},
+                    "reasons": ["negative_plays_pg_api:empty_response"],
+                },
+                "pff": {
+                    "status": "unavailable",
+                    "fields": {
+                        "pff_missed_tackles_pg": "N/A",
+                        "pff_tfl_pg": "N/A",
+                        "pff_sacks_pg": "N/A",
+                    },
+                    "reasons": ["pff_tackling:HTTPError: 403"],
+                },
+            },
+            "_source": "yr-data-api",
+        }
+    }
+
+    merged = loaders.merge_enrichment_payload(existing, refreshed)
+
+    washington = merged["washington"]
+    assert washington["pff_missed_tackles_pg"] == "4.1"
+    assert washington["pff_tfl_pg"] == "7.2"
+    assert washington["pff_sacks_pg"] == "2.9"
+    assert washington["_status"] == "ok"
+    assert washington["_providers"]["pff"]["status"] == "unavailable"
+    assert washington["_providers"]["pff"]["fields"]["pff_missed_tackles_pg"] == "4.1"
+    assert washington["_providers"]["pff"]["reasons"] == ["pff_tackling:HTTPError: 403"]
+
+
+def test_gather_team_data_exposes_enrichment_provider_metadata() -> None:
+    pbp_teams = loaders.load_pbp_data(
+        season=2025,
+        bundle_source=PIPELINE_FIXTURES / "pbp_stats_bundle_2025.json",
+    )
+    team = loaders.gather_team_data(
+        pbp_teams,
+        "Washington",
+        2025,
+        enrichment_by_slug={
+            "washington": {
+                "pff_missed_tackles_pg": "4.1",
+                "_providers": {
+                    "pff": {
+                        "status": "partial",
+                        "fields": {"pff_missed_tackles_pg": "4.1"},
+                        "reasons": ["pff_tackling:zero_placeholder_response"],
+                    }
+                },
+            }
+        },
+    )
+
+    assert team["stats"]["pff_missed_tackles_pg"] == "4.1"
+    assert team["enrichment"]["_status"] == "ok"
+    assert team["enrichment"]["_providers"]["pff"]["status"] == "partial"
+    assert "pff_tackling:zero_placeholder_response" in team["enrichment"]["_providers"]["pff"]["reasons"]
+
+
+def test_renderers_prefer_provider_metadata_for_enrichment_warning() -> None:
+    team1 = {
+        "display_name": "Washington",
+        "stats": {},
+        "enrichment": {
+            "_providers": {
+                "pff": {
+                    "status": "partial",
+                    "fields": {},
+                    "reasons": ["pff_tackling:zero_placeholder_response"],
+                }
+            }
+        },
+    }
+    team2 = {
+        "display_name": "Ohio State",
+        "stats": {},
+        "enrichment": {
+            "_providers": {
+                "blitz": {
+                    "status": "unavailable",
+                    "fields": {},
+                    "reasons": ["blitz_pct:TimeoutError"],
+                }
+            }
+        },
+    }
+
+    markdown_warning = markdown_renderer._missing_warning(team1, team2)
+    html_warning = html_renderer._missing_warning(team1, team2)
+
+    for warning in (markdown_warning, html_warning):
+        assert "Enrichment snapshot issues:" in warning
+        assert "Washington (PFF partial (placeholder zeros))" in warning
+        assert "Ohio State (Blitz unavailable (timeout))" in warning


### PR DESCRIPTION
## Summary
This finishes the `#149` reliability slice for enrichment-backed brief data without changing the published pipeline summary contract.

The main change is that enrichment artifacts now carry provider-level status envelopes under each team entry, and the brief renderers use that metadata to emit explicit data notices instead of only inferring trouble from `N/A` fields.

## What changed
- Added `_providers` metadata to normalized/live enrichment payloads in `scripts/game_prep_brief/loaders.py`.
- Kept top-level team `_status` coarse (`ok` / `unavailable`) so the existing pipeline summary and publishability logic stay stable.
- Made yr-data-api fetch failures explicit at fetch time via `_fetch_text_result_from_candidates(...)`, with provider-specific reason capture.
- Marked historical `0\t0\t0` PFF tackling responses as a placeholder/unavailable condition instead of treating them as real data.
- Attached normalized enrichment metadata to `gather_team_data(...)` return values so renderers can inspect provider state directly.
- Updated the markdown and HTML renderers to prefer provider metadata for the top-level enrichment warning banner.
- Documented the `_providers` contract in `docs/enrichment-artifact-contract.md`.

## Schema / contract decisions
### Top-level `_status`
I intentionally did **not** expand the top-level enrichment status to include `partial`.

Reasoning:
- the pipeline summary currently reduces team status into `validated`, `validated_with_unavailable_teams`, etc.
- changing team `_status` would ripple into `refresh-game-prep-pipeline.sh`, `live_refresh_ops.py`, and the published summary contract
- `#149` is about making provider failures explicit, not changing publishability semantics

So the team-level contract remains:
- `ok`: at least one enrichment field has usable signal
- `unavailable`: the team entry exists but no enrichment signal is usable

### Provider-level `_providers`
The new `_providers` block is the source of truth for partial/unavailable state:
- `status`: `ok`, `partial`, `unavailable`
- `fields`: the stored values for that provider's enrichment keys
- `reasons`: machine-readable fetch/parsing reasons

This is what the renderers now use for user-visible warnings.

### Merge behavior
`merge_enrichment_payload(...)` still preserves prior non-empty flat values when a live refresh comes back empty.

What changed is that the preserved values no longer silently hide the failure:
- the flat values remain usable for rendering
- the provider envelope records the current fetch failure status/reasons
- the renderer warning can now say the snapshot is partial/unavailable even when a stale preserved value is still present

## Tests
Added focused coverage in `tests/test_enrichment_provider_contract.py` for:
- PFF `0\t0\t0` placeholder handling
- merge-time preservation of prior values with explicit provider failure metadata
- `gather_team_data(...)` exposing enrichment provider metadata to sections/renderers
- markdown/html warning banners preferring provider metadata over generic missing-field heuristics

## Validation
Ran:

```bash
PYTHONPATH=. /Users/victorres/projects2/pbp/.venv/bin/python -m pytest -q \
  tests/test_enrichment_provider_contract.py \
  tests/test_game_prep_cli_enrichment.py \
  tests/test_game_prep_loader_artifacts.py \
  tests/test_pipeline_summary_contract.py \
  tests/test_game_prep_brief_golden.py \
  tests/test_scoring_zones_issue_158.py
```

Result:
- `18 passed`

## Why this closes the gap
Before this PR, the brief could only infer enrichment trouble indirectly from missing values, and merge-preserved data could mask live provider failures completely.

After this PR:
- provider failures are captured explicitly in the artifact
- fetch-time problems are logged where they occur
- the brief warns from provider status instead of guessing from `N/A`
- the pipeline summary contract remains backward-compatible
