### PR TITLE
Add TOP to post-turnover drive details

### DIFF
--- a/scripts/game_prep_brief/loaders.py
+++ b/scripts/game_prep_brief/loaders.py
@@ -548,7 +548,12 @@ def _converted_bundle_game(
             _int_or_none(raw_game.get("points_off_turnovers_allowed")),
             _int_or_none(points_off_turnovers.get("points_off_turnovers_allowed")),
         ),
-        "post_turnover_drives": _list_or_empty(raw_game.get("post_turnover_drives")),
+        "post_turnover_drives": _enrich_post_turnover_drives(
+            raw_game,
+            _list_or_empty(raw_game.get("post_turnover_drives")),
+            team_aliases=_abbr_set(raw_game.get("team")),
+            opp_aliases=_abbr_set(opponent_abbr),
+        ),
         "red_zone_trips": _pick_present(
             _int_or_none(raw_game.get("red_zone_trips")),
             _int_or_none(red_zone.get("rz_trips")),
@@ -635,6 +640,169 @@ def _iter_play_tree_drives(play_tree: object):
             plays = [p for p in (drive.get("plays") or []) if isinstance(p, dict)]
             if plays:
                 yield quarter_num, plays
+
+
+def _scrimmage_play_count(plays: list[dict]) -> int:
+    return sum(1 for play in plays if not play.get("is_no_play") and play.get("is_scrimmage_play"))
+
+
+def _clock_remaining_seconds(clock: object) -> int | None:
+    if not isinstance(clock, str):
+        return None
+    match = re.match(r"^\s*(\d{1,2}):(\d{2})\s*$", clock)
+    if not match:
+        return None
+    minutes = int(match.group(1))
+    seconds = int(match.group(2))
+    if seconds >= 60:
+        return None
+    return minutes * 60 + seconds
+
+
+def _clock_elapsed_seconds(quarter: object, clock: object) -> int | None:
+    if not isinstance(quarter, int) or quarter <= 0:
+        return None
+    remaining = _clock_remaining_seconds(clock)
+    if remaining is None:
+        return None
+    if quarter <= 4:
+        return ((quarter - 1) * 15 * 60) + ((15 * 60) - remaining)
+    return None
+
+
+def _format_drive_top(seconds: int | None) -> str | None:
+    if seconds is None or seconds < 0:
+        return None
+    minutes, remainder = divmod(seconds, 60)
+    return f"{minutes}:{remainder:02d}"
+
+
+def _drive_side(plays: list[dict], resolver: "_PlaySideResolver") -> str | None:
+    for play in plays:
+        if play.get("is_no_play") or not play.get("is_scrimmage_play"):
+            continue
+        side = resolver.resolve(play.get("offense"))
+        if side in {"team", "opp"}:
+            return side
+    return None
+
+
+def _find_turnover_drive_index(
+    flat_drives: list[tuple[int | None, list[dict]]],
+    entry: dict,
+) -> int | None:
+    target_desc = str(entry.get("turnover_description") or "").strip()
+    target_clock = str(entry.get("clock") or "").strip()
+    target_quarter = entry.get("quarter")
+    for idx, (quarter, plays) in enumerate(flat_drives):
+        for play in plays:
+            if play.get("is_no_play"):
+                continue
+            desc = str(play.get("description") or "").strip()
+            clock = str(play.get("clock") or "").strip()
+            if target_desc and desc != target_desc:
+                continue
+            if target_clock and clock != target_clock:
+                continue
+            play_quarter = play.get("quarter")
+            quarter_value = play_quarter if isinstance(play_quarter, int) else quarter
+            if isinstance(target_quarter, int) and quarter_value != target_quarter:
+                continue
+            return idx
+    return None
+
+
+def _matched_post_turnover_drive_segments(
+    flat_drives: list[tuple[int | None, list[dict]]],
+    entry: dict,
+    resolver: "_PlaySideResolver",
+) -> list[tuple[int | None, list[dict]]]:
+    turnover_drive_idx = _find_turnover_drive_index(flat_drives, entry)
+    if turnover_drive_idx is None:
+        return []
+
+    expected_side = "team" if entry.get("side") == "team_gained" else "opp"
+    expected_plays = entry.get("num_plays") if isinstance(entry.get("num_plays"), int) else None
+    collected: list[tuple[int | None, list[dict]]] = []
+    total_scrimmage_plays = 0
+
+    for drive_idx in range(turnover_drive_idx + 1, len(flat_drives)):
+        quarter, plays = flat_drives[drive_idx]
+        drive_side = _drive_side(plays, resolver)
+        if drive_side != expected_side:
+            if collected:
+                break
+            continue
+        if not _scrimmage_play_count(plays):
+            continue
+        collected.append((quarter, plays))
+        total_scrimmage_plays += _scrimmage_play_count(plays)
+        if expected_plays is not None and total_scrimmage_plays >= expected_plays:
+            break
+
+    return collected
+
+
+def _drive_top_seconds(drive_segments: list[tuple[int | None, list[dict]]]) -> int | None:
+    first_elapsed: int | None = None
+    last_elapsed: int | None = None
+
+    for quarter, plays in drive_segments:
+        valid_plays = [play for play in plays if not play.get("is_no_play") and play.get("clock")]
+        if not valid_plays:
+            continue
+        first_play = valid_plays[0]
+        last_play = valid_plays[-1]
+        start_elapsed = _clock_elapsed_seconds(
+            first_play.get("quarter") if isinstance(first_play.get("quarter"), int) else quarter,
+            first_play.get("clock"),
+        )
+        end_elapsed = _clock_elapsed_seconds(
+            last_play.get("quarter") if isinstance(last_play.get("quarter"), int) else quarter,
+            last_play.get("clock"),
+        )
+        if first_elapsed is None and start_elapsed is not None:
+            first_elapsed = start_elapsed
+        if end_elapsed is not None:
+            last_elapsed = end_elapsed
+
+    if first_elapsed is None or last_elapsed is None or last_elapsed < first_elapsed:
+        return None
+    return last_elapsed - first_elapsed
+
+
+def _enrich_post_turnover_drives(
+    raw_game: dict,
+    entries: list[dict],
+    *,
+    team_aliases: set[str],
+    opp_aliases: set[str],
+) -> list[dict]:
+    if not entries:
+        return []
+    play_tree = raw_game.get("play_tree")
+    if not isinstance(play_tree, list) or not play_tree:
+        return entries
+
+    resolver = _build_play_side_resolver(raw_game, team_aliases=team_aliases, opp_aliases=opp_aliases)
+    flat_drives = list(_iter_play_tree_drives(play_tree))
+    if not flat_drives:
+        return entries
+
+    enriched: list[dict] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        out = dict(entry)
+        segments = _matched_post_turnover_drive_segments(flat_drives, out, resolver)
+        top_seconds = _drive_top_seconds(segments)
+        if top_seconds is None and str(out.get("drive_result") or "").upper() == "DEF TD":
+            top_seconds = 0
+        if top_seconds is not None:
+            out["drive_top_seconds"] = top_seconds
+            out["drive_top"] = _format_drive_top(top_seconds)
+        enriched.append(out)
+    return enriched
 
 
 def _desc_contains_alias(desc_up: str, aliases: set[str]) -> bool:

--- a/scripts/game_prep_brief/sections/turnovers.py
+++ b/scripts/game_prep_brief/sections/turnovers.py
@@ -34,6 +34,7 @@ def _post_turnover_drives(games: list[dict]) -> dict:
                 "result": d.get("drive_result", "?"),
                 "yards": d.get("total_yards", "?"),
                 "num_plays": d.get("num_plays", "?"),
+                "top": d.get("drive_top"),
                 "points": d.get("points_scored", 0),
                 "turnover_type": d.get("turnover_type", "?"),
             }
@@ -133,9 +134,11 @@ def _team_html(team: dict) -> str:
             def _drive_line(d: dict) -> str:
                 pts = d.get("points", 0) or 0
                 pts_str = f", {pts} pts" if pts else ""
+                top = d.get("top")
+                top_str = f", TOP {top}" if top else ""
                 return (
                     f"<li>{d['turnover_type']} \u2192 {d['result']}"
-                    f"{pts_str}, {d['yards']} yds, {d['num_plays']} plays</li>"
+                    f"{pts_str}, {d['yards']} yds, {d['num_plays']} plays{top_str}</li>"
                 )
             inner = "".join(_drive_line(d) for d in drives)
             parts.append(f"<ul>{inner}</ul></li>")

--- a/tests/test_post_turnover_drive_top.py
+++ b/tests/test_post_turnover_drive_top.py
@@ -1,0 +1,260 @@
+from scripts.game_prep_brief import loaders
+from scripts.game_prep_brief.sections import turnovers
+
+
+def _play(
+    description: str,
+    *,
+    offense: str,
+    clock: str,
+    quarter: int,
+    is_turnover: bool = False,
+    is_no_play: bool = False,
+    is_scrimmage_play: bool = True,
+) -> dict:
+    return {
+        "quarter": quarter,
+        "offense": offense,
+        "clock": clock,
+        "description": description,
+        "is_turnover": is_turnover,
+        "is_no_play": is_no_play,
+        "is_scrimmage_play": is_scrimmage_play,
+    }
+
+
+def _drive(*plays: dict, offense: str | None = None) -> dict:
+    return {
+        "offense": offense,
+        "plays": list(plays),
+    }
+
+
+def _raw_game(*quarters: dict) -> dict:
+    return {
+        "team": "UW",
+        "opponent_abbr": "OSU",
+        "play_tree": list(quarters),
+    }
+
+
+def _quarter(number: int, *drives: dict) -> dict:
+    return {"quarter": number, "drives": list(drives)}
+
+
+def test_enrich_post_turnover_drives_adds_same_quarter_top() -> None:
+    turnover_desc = "OSU pass intercepted by UW at the UW35"
+    raw_game = _raw_game(
+        _quarter(
+            1,
+            _drive(
+                _play(turnover_desc, offense="OSU", clock="10:00", quarter=1, is_turnover=True),
+                offense="OSU",
+            ),
+            _drive(
+                _play("UW rush for 4", offense="UW", clock="9:40", quarter=1),
+                _play("UW rush for 6", offense="UW", clock="9:05", quarter=1),
+                _play("UW field goal good", offense="UW", clock="8:35", quarter=1),
+                offense="UW",
+            ),
+        )
+    )
+
+    entries = [
+        {
+            "side": "team_gained",
+            "quarter": 1,
+            "clock": "10:00",
+            "turnover_description": turnover_desc,
+            "drive_result": "FG",
+            "num_plays": 3,
+            "total_yards": 19,
+            "points_scored": 3,
+            "turnover_type": "INT",
+        }
+    ]
+
+    enriched = loaders._enrich_post_turnover_drives(
+        raw_game,
+        entries,
+        team_aliases={"UW"},
+        opp_aliases={"OSU"},
+    )
+
+    assert enriched[0]["drive_top_seconds"] == 65
+    assert enriched[0]["drive_top"] == "1:05"
+
+
+def test_enrich_post_turnover_drives_spans_quarter_boundary() -> None:
+    turnover_desc = "OSU rush fumbled and recovered by UW at the UW20"
+    raw_game = _raw_game(
+        _quarter(
+            1,
+            _drive(
+                _play(turnover_desc, offense="OSU", clock="0:20", quarter=1, is_turnover=True),
+                offense="OSU",
+            ),
+            _drive(
+                _play("UW rush for 5", offense="UW", clock="0:15", quarter=1),
+                _play("UW rush for 7", offense="UW", clock="0:03", quarter=1),
+                offense="UW",
+            ),
+        ),
+        _quarter(
+            2,
+            _drive(
+                _play("UW rush for 3", offense="UW", clock="15:00", quarter=2),
+                _play("UW punt", offense="UW", clock="14:38", quarter=2),
+                offense="UW",
+            )
+        ),
+    )
+
+    entries = [
+        {
+            "side": "team_gained",
+            "quarter": 1,
+            "clock": "0:20",
+            "turnover_description": turnover_desc,
+            "drive_result": "PUNT",
+            "num_plays": 4,
+            "total_yards": 15,
+            "points_scored": 0,
+            "turnover_type": "FUM",
+        }
+    ]
+
+    enriched = loaders._enrich_post_turnover_drives(
+        raw_game,
+        entries,
+        team_aliases={"UW"},
+        opp_aliases={"OSU"},
+    )
+
+    assert enriched[0]["drive_top_seconds"] == 37
+    assert enriched[0]["drive_top"] == "0:37"
+
+
+def test_enrich_post_turnover_drives_sets_zero_top_for_defensive_touchdown() -> None:
+    turnover_desc = "OSU pass intercepted by UW and returned for touchdown"
+    raw_game = _raw_game(
+        _quarter(
+            1,
+            _drive(
+                _play(turnover_desc, offense="OSU", clock="11:22", quarter=1, is_turnover=True),
+                offense="OSU",
+            )
+        )
+    )
+
+    entries = [
+        {
+            "side": "team_gained",
+            "quarter": 1,
+            "clock": "11:22",
+            "turnover_description": turnover_desc,
+            "drive_result": "DEF TD",
+            "num_plays": 0,
+            "total_yards": 0,
+            "points_scored": 7,
+            "turnover_type": "INT",
+        }
+    ]
+
+    enriched = loaders._enrich_post_turnover_drives(
+        raw_game,
+        entries,
+        team_aliases={"UW"},
+        opp_aliases={"OSU"},
+    )
+
+    assert enriched[0]["drive_top_seconds"] == 0
+    assert enriched[0]["drive_top"] == "0:00"
+
+
+def test_enrich_post_turnover_drives_omits_top_for_overtime_drive() -> None:
+    turnover_desc = "OSU rush fumbled and recovered by UW in overtime"
+    raw_game = _raw_game(
+        _quarter(
+            5,
+            _drive(
+                _play(turnover_desc, offense="OSU", clock="0:00", quarter=5, is_turnover=True),
+                offense="OSU",
+            ),
+            _drive(
+                _play("UW rush for 2", offense="UW", clock="0:00", quarter=5),
+                _play("UW field goal good", offense="UW", clock="0:00", quarter=5),
+                offense="UW",
+            ),
+        )
+    )
+
+    entries = [
+        {
+            "side": "team_gained",
+            "quarter": 5,
+            "clock": "0:00",
+            "turnover_description": turnover_desc,
+            "drive_result": "FG",
+            "num_plays": 2,
+            "total_yards": 2,
+            "points_scored": 3,
+            "turnover_type": "FUM",
+        }
+    ]
+
+    enriched = loaders._enrich_post_turnover_drives(
+        raw_game,
+        entries,
+        team_aliases={"UW"},
+        opp_aliases={"OSU"},
+    )
+
+    assert "drive_top_seconds" not in enriched[0]
+    assert "drive_top" not in enriched[0]
+
+
+def test_turnovers_html_renders_drive_top_detail() -> None:
+    team = {
+        "display_name": "Washington",
+        "has_pbp": True,
+        "stats": {
+            "source_points_off_turnovers_for": 7,
+            "source_points_off_turnovers_against": 0,
+            "source_post_turnover_drives_for": 1,
+            "source_post_turnover_drives_against": 0,
+        },
+        "last_n": {"actual_n": 1, "required_n": 3},
+        "pbp_entry": {
+            "aggregates": {"turnover_margin": 1},
+            "games": [
+                {
+                    "game_number": 1,
+                    "opponent": "Ohio State",
+                    "turnovers_gained": 1,
+                    "turnovers_lost": 0,
+                    "interceptions_gained": 1,
+                    "interceptions_lost": 0,
+                    "fumbles_gained": 0,
+                    "fumbles_lost": 0,
+                    "points_off_turnovers_for": 7,
+                    "points_off_turnovers_against": 0,
+                    "post_turnover_drives": [
+                        {
+                            "side": "team_gained",
+                            "drive_result": "TD",
+                            "total_yards": 42,
+                            "num_plays": 5,
+                            "drive_top": "1:05",
+                            "points_scored": 7,
+                            "turnover_type": "INT",
+                        }
+                    ],
+                }
+            ],
+        },
+    }
+
+    html = turnovers.build(team, team)["html_content"]
+
+    assert "TOP 1:05" in html


### PR DESCRIPTION
## Summary
- compute per-drive TOP for bundle-backed `post_turnover_drives` by matching each exported turnover entry back to `play_tree` drive segments
- carry the derived `drive_top` / `drive_top_seconds` fields into the turnover detail rendering path
- add focused regression coverage for same-quarter, quarter-boundary, defensive-score, and overtime cases

## Issue
- closes #170

## What changed
Step 1 of the change is in `scripts/game_prep_brief/loaders.py`.

`_converted_bundle_game()` now passes raw `post_turnover_drives` through `_enrich_post_turnover_drives(...)` instead of returning the bundle entry untouched. The enrichment logic:
- re-finds each turnover event in the game `play_tree` using `turnover_description`, `clock`, and `quarter`
- walks the ensuing drive list with the existing play-side resolver so the drive is attributed to the correct side even when the play text uses aliases
- stitches together adjacent same-side drive segments when a post-turnover possession crosses a quarter boundary
- computes approximate TOP from the first and last play clocks in those matched segments
- writes `drive_top_seconds` and display-ready `drive_top` back onto the exported entry

The approximation is intentionally conservative: it measures elapsed game-clock time from the first matched play to the last matched play and does not attempt to infer the hidden duration of the final snap. For defensive return touchdowns with no ensuing possession, it exports `0:00` instead of leaving the value blank.

Step 2 is in `scripts/game_prep_brief/sections/turnovers.py`.

The HTML post-turnover drive detail list now renders `TOP {drive_top}` when the enriched value is present. The markdown turnover section remains unchanged because it still summarizes only season and last-N turnover/POT totals, not individual drive detail rows.

## Tests
Added `tests/test_post_turnover_drive_top.py` covering:
- same-quarter TOP derivation
- quarter-boundary continuation
- defensive touchdown fallback to `0:00`
- overtime drives omitting TOP instead of miscomputing it
- turnover section HTML rendering the new TOP detail

Also reran the existing artifact-backed brief slice to make sure this did not shift markdown/golden output.

## Validation
```bash
PYTHONPATH=. /Users/victorres/projects2/pbp/.venv/bin/python -m pytest -q \
  tests/test_post_turnover_drive_top.py \
  tests/test_play_tree_alias_resolver.py \
  tests/test_game_prep_loader_artifacts.py \
  tests/test_game_prep_brief_golden.py \
  tests/test_scoring_zones_issue_158.py
```

Result: `20 passed`
