### PR TITLE
Count scrambles in explosive play context

### DIFF
--- a/scripts/game_prep_brief/sections/explosives.py
+++ b/scripts/game_prep_brief/sections/explosives.py
@@ -234,6 +234,8 @@ def _iter_offensive_plays(game: dict, team_abbr: object) -> list[dict]:
                     continue
                 if play.get("is_no_play"):
                     continue
+                if play.get("is_scrimmage_play") is False:
+                    continue
                 out.append(play)
     return out
 
@@ -242,6 +244,8 @@ def _is_rush(desc: str) -> bool:
     d = desc.lower()
     if "kneel" in d:
         return False
+    if "scrambl" in d:
+        return True
     return " rush " in f" {d} "
 
 

--- a/tests/test_explosives_section_issue_156.py
+++ b/tests/test_explosives_section_issue_156.py
@@ -39,11 +39,11 @@ def test_explosives_section_uses_play_tree_counts_for_pbp_context() -> None:
     washington_game_row_totals = explosives._game_row_aggregate_explosives(washington["pbp_entry"]["games"])
     ohio_state_game_row_totals = explosives._game_row_aggregate_explosives(ohio_state["pbp_entry"]["games"])
 
-    assert washington_totals["explosives"] == 83
+    assert washington_totals["explosives"] == 86
     assert washington_totals["explosive_passes"] == 48
-    assert washington_totals["explosive_rushes"] == 35
+    assert washington_totals["explosive_rushes"] == 38
     assert washington_totals["pass_20_plus"] == 48
-    assert washington_totals["rush_20_plus"] == 21
+    assert washington_totals["rush_20_plus"] == 24
     assert washington_totals["rush_15_19"] == 14
     assert washington_game_row_totals == {
         "explosives": 100,
@@ -70,8 +70,63 @@ def test_explosives_markdown_surfaces_play_tree_counts_and_bundle_row_gap() -> N
 
     md = explosives.build(washington, ohio_state)["md_content"]
 
-    assert "- PBP Explosives: 83 (Pass 48, Rush 35)" in md
-    assert "- Delta using PBP 20+ vs CFBStats: -4 (-5.5%) (residual -4)" in md
+    assert "- PBP Explosives: 86 (Pass 48, Rush 38)" in md
+    assert "- Delta using PBP 20+ vs CFBStats: -1 (-1.4%) (residual -1)" in md
 
     assert "- PBP Explosives: 71 (Pass 45, Rush 26)" in md
     assert "- Delta using PBP 20+ vs CFBStats: 0 (0.0%) (residual 0)" in md
+
+
+def test_explosives_treat_scrambles_as_runs_but_ignore_special_teams_returns() -> None:
+    team = {
+        "display_name": "Washington",
+        "has_pbp": True,
+        "stats": {"abbr": "UW"},
+        "last_n": {"actual_n": 0, "required_n": 3},
+        "pbp_entry": {
+            "abbr": "UW",
+            "abbr_aliases": ["UW"],
+            "cfbstats": {"rankings": {"all": {"explosives": {"value": "1", "rank": 1}}}},
+            "games": [
+                {
+                    "game_number": 1,
+                    "opponent": "OSU",
+                    "play_tree": [
+                        {
+                            "quarter": 1,
+                            "drives": [
+                                {
+                                    "plays": [
+                                        {
+                                            "offense": "UW",
+                                            "description": "WILLIAMS JR., Demond scrambles to the right for a gain of 21 yards to the OSU25",
+                                            "yards": 21,
+                                            "is_no_play": False,
+                                            "is_scrimmage_play": True,
+                                        },
+                                        {
+                                            "offense": "UW",
+                                            "description": "MOCZULSKI, Ethan kickoff 65 yards from the UW35 to the OSU0, return 25 yards",
+                                            "yards": 25,
+                                            "is_no_play": False,
+                                            "is_scrimmage_play": False,
+                                        },
+                                    ]
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+        },
+    }
+
+    totals = explosives._aggregate_explosives(
+        team["pbp_entry"]["games"],
+        explosives._team_aliases(team),
+    )
+
+    assert totals["explosives"] == 1
+    assert totals["explosive_passes"] == 0
+    assert totals["explosive_rushes"] == 1
+    assert totals["rush_20_plus"] == 1


### PR DESCRIPTION
## Summary
- count QB scrambles as rushing explosives in the brief play-tree context
- ignore non-scrimmage plays when deriving offensive explosive totals
- add a focused regression for scramble-vs-return classification

## Why
PR #217 fixed the section so `PBP Explosives` came from play-tree counts instead of bundle game-row counters, but Washington still showed a residual `-4` after 20+ normalization. The remaining gap was partially artificial: the section was not treating `scrambles` as rushing plays, and it could still iterate non-scrimmage special-teams returns when scanning offensive plays.

This follow-up closes that classification gap.

## Result
Washington now renders:
- `PBP Explosives: 86 (Pass 48, Rush 38)`
- `Delta using PBP 20+ vs CFBStats: -1 (-1.4%) (residual -1)`

Ohio State remains unchanged:
- `PBP Explosives: 71 (Pass 45, Rush 26)`
- `Delta using PBP 20+ vs CFBStats: 0 (0.0%) (residual 0)`

So the unresolved Washington discrepancy is narrowed from 4 plays to 1 play.

## Validation
```bash
PYTHONPATH=. /Users/victorres/projects2/pbp/.venv/bin/python -m pytest -q 
  tests/test_explosives_section_issue_156.py 
  tests/test_game_prep_loader_artifacts.py 
  tests/test_scoring_zones_issue_158.py 
  tests/test_game_prep_brief_golden.py
```

Passed: `11 passed`
