### PR TITLE
Add operator dashboard MVP for brief pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,23 @@ Notes:
   - then two-token elimination for feed variants like `UW` vs `WAS`/`WASH`
   - if a new feed alias appears, extend the team's `abbr_aliases` rather than patching individual stat paths
 
+### Operator Dashboard
+
+The refresh pipeline now has a thin operator UI at [operator/index.html](./operator/index.html).
+
+- Deployed route: `/operator/`
+- Purpose: launch `Brief Live Refresh`, inspect the newest workflow run, and verify the rolling `brief-artifacts-<season>` release without introducing a new backend
+- Source of truth stays the same:
+  - GitHub Actions for live runs
+  - GitHub Releases for published artifacts
+  - `game_prep_pipeline_summary_<season>.json` for machine-readable run state
+- GitHub auth:
+  - dispatch requires a token
+  - private workflow/release reads also require a token
+  - the page stores a token in browser local storage only when you explicitly click `Save token locally`
+
+For workflow details, publication rules, freshness, and rollback, use [docs/demo-runbook.md](./docs/demo-runbook.md).
+
 ### Generate Data
 ```bash
 cd ~/clawd/pbp-parser

--- a/docs/demo-runbook.md
+++ b/docs/demo-runbook.md
@@ -49,6 +49,27 @@ Important: the `yr-data-api/data/pbp_stats_bundle.json` write is a **local hando
 
 The official operator workflow is [`.github/workflows/brief-live-refresh.yml`](../.github/workflows/brief-live-refresh.yml). It runs the same `live-refresh` path as the local script, but publishes the season-core artifact set to a GitHub release instead of depending on `yr-data-api`.
 
+### Operator Dashboard
+
+There is also a static operator dashboard at [operator/index.html](../operator/index.html). It is intentionally a thin control plane over the same GitHub-backed workflow and release contract.
+
+What it does:
+
+- dispatches `Brief Live Refresh` on `main`
+- shows the latest workflow run and recent run list
+- shows the rolling `brief-artifacts-<season>` last-known-good release
+- computes freshness from the published summary JSON
+- links operators to the runbook, releases, alert thread, and workflow page
+
+Auth model:
+
+- dispatch always requires a GitHub token
+- private workflow/release reads also require a GitHub token
+- the page never proxies the token through a new service
+- `Save token locally` stores it in browser local storage only for that browser profile
+
+This keeps the dashboard aligned with the current operating model instead of inventing a second pipeline backend.
+
 Requirements:
 
 - run it from `main`

--- a/operator/app.js
+++ b/operator/app.js
@@ -1,0 +1,897 @@
+const DEFAULTS = {
+    repo: "victorres11/pbp-analysis",
+    workflowFile: "brief-live-refresh.yml",
+    team1: "Washington",
+    team2: "Ohio State",
+    season: "2025",
+    lastN: "3",
+    briefFormat: "markdown",
+    runTests: false,
+    strictVerification: true,
+    includeEnrichment: true,
+};
+
+const STORAGE_KEYS = {
+    repo: "brief-operator-repo",
+    token: "brief-operator-token",
+    dispatch: "brief-operator-dispatch",
+};
+
+const WORKFLOW_PAGE = (repo) => `https://github.com/${repo}/actions/workflows/${DEFAULTS.workflowFile}`;
+const RELEASES_PAGE = (repo) => `https://github.com/${repo}/releases`;
+const RUNBOOK_PAGE = (repo) => `https://github.com/${repo}/blob/main/docs/demo-runbook.md`;
+const CONTRACT_PAGE = (repo) => `https://github.com/${repo}/blob/main/docs/published-artifact-contract.md`;
+const ALERTS_PAGE = (repo) =>
+    `https://github.com/${repo}/issues?q=is%3Aissue%20state%3Aopen%20%22Brief%20Live%20Refresh%20Alerts%22`;
+
+const elements = {};
+let loading = false;
+
+document.addEventListener("DOMContentLoaded", () => {
+    cacheElements();
+    hydrateSettings();
+    bindEvents();
+    refreshDashboard();
+});
+
+function cacheElements() {
+    for (const id of [
+        "repoInput",
+        "tokenInput",
+        "team1Input",
+        "team2Input",
+        "seasonInput",
+        "lastNInput",
+        "briefFormatInput",
+        "runTestsInput",
+        "strictVerificationInput",
+        "includeEnrichmentInput",
+        "saveTokenButton",
+        "clearTokenButton",
+        "refreshButton",
+        "dispatchButton",
+        "settingsMessage",
+        "dispatchMessage",
+        "statusStrip",
+        "latestRunCard",
+        "publishedCard",
+        "freshnessCard",
+        "operatorNoteCard",
+        "runsPanel",
+        "publishedSummaryPanel",
+        "assetPanel",
+        "quickLinksPanel",
+        "workflowLink",
+        "rollingReleaseLink",
+        "settingsForm",
+        "dispatchForm",
+    ]) {
+        elements[id] = document.getElementById(id);
+    }
+}
+
+function hydrateSettings() {
+    const savedRepo = localStorage.getItem(STORAGE_KEYS.repo);
+    const savedToken = localStorage.getItem(STORAGE_KEYS.token);
+    const savedDispatch = loadJsonStorage(STORAGE_KEYS.dispatch);
+
+    if (savedRepo) {
+        elements.repoInput.value = savedRepo;
+    }
+    if (savedToken) {
+        elements.tokenInput.value = savedToken;
+        setInlineMessage(
+            elements.settingsMessage,
+            "Using a token saved in this browser. You can still overwrite it for the current session.",
+            "success",
+        );
+    }
+    if (savedDispatch) {
+        elements.team1Input.value = savedDispatch.team1 || DEFAULTS.team1;
+        elements.team2Input.value = savedDispatch.team2 || DEFAULTS.team2;
+        elements.seasonInput.value = savedDispatch.season || DEFAULTS.season;
+        elements.lastNInput.value = savedDispatch.lastN || DEFAULTS.lastN;
+        elements.briefFormatInput.value = savedDispatch.briefFormat || DEFAULTS.briefFormat;
+        elements.runTestsInput.checked = Boolean(savedDispatch.runTests);
+        elements.strictVerificationInput.checked = savedDispatch.strictVerification !== false;
+        elements.includeEnrichmentInput.checked = savedDispatch.includeEnrichment !== false;
+    }
+}
+
+function bindEvents() {
+    elements.refreshButton.addEventListener("click", () => refreshDashboard());
+    elements.saveTokenButton.addEventListener("click", saveTokenLocally);
+    elements.clearTokenButton.addEventListener("click", clearSavedToken);
+    elements.settingsForm.addEventListener("submit", (event) => event.preventDefault());
+    elements.dispatchForm.addEventListener("submit", handleDispatch);
+
+    elements.repoInput.addEventListener("change", handleRepoChanged);
+    elements.seasonInput.addEventListener("change", handleDispatchSettingsChanged);
+    elements.tokenInput.addEventListener("input", syncActionButtons);
+
+    for (const field of [
+        elements.team1Input,
+        elements.team2Input,
+        elements.lastNInput,
+        elements.briefFormatInput,
+        elements.runTestsInput,
+        elements.strictVerificationInput,
+        elements.includeEnrichmentInput,
+    ]) {
+        field.addEventListener("change", persistDispatchSettings);
+    }
+}
+
+function handleRepoChanged() {
+    localStorage.setItem(STORAGE_KEYS.repo, normalizedRepo());
+    refreshQuickLinks();
+}
+
+function handleDispatchSettingsChanged() {
+    persistDispatchSettings();
+    refreshQuickLinks();
+}
+
+function persistDispatchSettings() {
+    localStorage.setItem(
+        STORAGE_KEYS.dispatch,
+        JSON.stringify({
+            team1: elements.team1Input.value.trim() || DEFAULTS.team1,
+            team2: elements.team2Input.value.trim() || DEFAULTS.team2,
+            season: elements.seasonInput.value.trim() || DEFAULTS.season,
+            lastN: elements.lastNInput.value.trim() || DEFAULTS.lastN,
+            briefFormat: elements.briefFormatInput.value,
+            runTests: elements.runTestsInput.checked,
+            strictVerification: elements.strictVerificationInput.checked,
+            includeEnrichment: elements.includeEnrichmentInput.checked,
+        }),
+    );
+}
+
+function saveTokenLocally() {
+    const token = elements.tokenInput.value.trim();
+    if (!token) {
+        setInlineMessage(elements.settingsMessage, "Paste a token before saving it locally.", "warning");
+        return;
+    }
+    localStorage.setItem(STORAGE_KEYS.token, token);
+    syncActionButtons();
+    setInlineMessage(elements.settingsMessage, "Saved token in this browser for future dashboard sessions.", "success");
+}
+
+function clearSavedToken() {
+    localStorage.removeItem(STORAGE_KEYS.token);
+    elements.tokenInput.value = "";
+    syncActionButtons();
+    setInlineMessage(elements.settingsMessage, "Cleared the saved token. The dashboard is back in read-only/session mode.", "warning");
+}
+
+async function handleDispatch(event) {
+    event.preventDefault();
+
+    const token = elements.tokenInput.value.trim();
+    if (!token) {
+        setInlineMessage(
+            elements.dispatchMessage,
+            "Dispatch needs a GitHub token. Add one above, then try again.",
+            "warning",
+        );
+        return;
+    }
+
+    const repo = normalizedRepo();
+    const inputs = {
+        team1: elements.team1Input.value.trim() || DEFAULTS.team1,
+        team2: elements.team2Input.value.trim() || DEFAULTS.team2,
+        season: elements.seasonInput.value.trim() || DEFAULTS.season,
+        last_n: elements.lastNInput.value.trim() || DEFAULTS.lastN,
+        brief_format: elements.briefFormatInput.value || DEFAULTS.briefFormat,
+        run_tests: String(elements.runTestsInput.checked),
+        strict_verification: String(elements.strictVerificationInput.checked),
+        include_enrichment: String(elements.includeEnrichmentInput.checked),
+    };
+    persistDispatchSettings();
+
+    elements.dispatchButton.disabled = true;
+    setInlineMessage(
+        elements.dispatchMessage,
+        `Dispatching a new live refresh for ${inputs.team1} vs ${inputs.team2} (${inputs.season})…`,
+        "warning",
+    );
+
+    try {
+        await githubRequest(
+            `/repos/${encodeRepo(repo)}/actions/workflows/${encodeURIComponent(DEFAULTS.workflowFile)}/dispatches`,
+            {
+                method: "POST",
+                token,
+                body: {
+                    ref: "main",
+                    inputs,
+                },
+            },
+        );
+        setInlineMessage(
+            elements.dispatchMessage,
+            `Dispatch accepted by GitHub. The new run should appear in a few seconds. Manual runs still publish only if they stay healthy and publishable.`,
+            "success",
+        );
+        window.setTimeout(() => refreshDashboard({ quiet: true }), 5000);
+    } catch (error) {
+        setInlineMessage(elements.dispatchMessage, formatError(error), "error");
+    } finally {
+        syncActionButtons();
+    }
+}
+
+async function refreshDashboard({ quiet = false } = {}) {
+    const repo = normalizedRepo();
+    const season = normalizedSeason();
+    const token = elements.tokenInput.value.trim();
+
+    localStorage.setItem(STORAGE_KEYS.repo, repo);
+    persistDispatchSettings();
+
+    refreshQuickLinks();
+    setLoadingState(true);
+
+    const [runsResult, publishedResult] = await Promise.allSettled([
+        fetchWorkflowRuns(repo, token),
+        fetchPublishedSeason(repo, season, token),
+    ]);
+
+    renderLatestRunBlock(runsResult, repo);
+    renderPublishedBlock(publishedResult, repo, season);
+    renderOverviewCards(runsResult, publishedResult, repo, season);
+
+    if (!quiet) {
+        const successCount = [runsResult, publishedResult].filter((result) => result.status === "fulfilled").length;
+        const message =
+            successCount === 2
+                ? "Dashboard refreshed from GitHub."
+                : "Dashboard refreshed with partial data. Add a token if you need private workflow or release access.";
+        const tone = successCount === 2 ? "success" : "warning";
+        setInlineMessage(elements.settingsMessage, message, tone);
+    }
+
+    setLoadingState(false);
+}
+
+async function fetchWorkflowRuns(repo, token) {
+    const payload = await githubRequest(
+        `/repos/${encodeRepo(repo)}/actions/workflows/${encodeURIComponent(DEFAULTS.workflowFile)}/runs?per_page=8`,
+        { token },
+    );
+    return {
+        workflowUrl: WORKFLOW_PAGE(repo),
+        runs: Array.isArray(payload.workflow_runs) ? payload.workflow_runs : [],
+    };
+}
+
+async function fetchPublishedSeason(repo, season, token) {
+    const tag = `brief-artifacts-${season}`;
+    const release = await githubRequest(`/repos/${encodeRepo(repo)}/releases/tags/${encodeURIComponent(tag)}`, {
+        token,
+    });
+    const summaryFilename = `game_prep_pipeline_summary_${season}.json`;
+    const summaryAsset = Array.isArray(release.assets)
+        ? release.assets.find((asset) => asset && asset.name === summaryFilename)
+        : null;
+
+    let summary = null;
+    if (summaryAsset && typeof summaryAsset.url === "string") {
+        summary = await githubRequest(summaryAsset.url, {
+            token,
+            accept: "application/octet-stream",
+        });
+    }
+
+    return {
+        tag,
+        release,
+        summary,
+        summaryAsset,
+    };
+}
+
+async function githubRequest(pathOrUrl, { method = "GET", token = "", accept = "application/vnd.github+json", body } = {}) {
+    const url = pathOrUrl.startsWith("http") ? pathOrUrl : `https://api.github.com${pathOrUrl}`;
+    const headers = {
+        Accept: accept,
+        "X-GitHub-Api-Version": "2022-11-28",
+    };
+    if (token) {
+        headers.Authorization = `Bearer ${token}`;
+    }
+    if (body !== undefined) {
+        headers["Content-Type"] = "application/json";
+    }
+
+    const response = await fetch(url, {
+        method,
+        headers,
+        body: body === undefined ? undefined : JSON.stringify(body),
+    });
+
+    if (response.status === 204) {
+        return null;
+    }
+
+    if (!response.ok) {
+        const message = await extractErrorMessage(response);
+        throw new Error(message);
+    }
+
+    const contentType = response.headers.get("content-type") || "";
+    if (contentType.includes("application/json") || contentType.includes("application/octet-stream")) {
+        return response.json();
+    }
+    return response.text();
+}
+
+async function extractErrorMessage(response) {
+    const fallback = `GitHub API request failed (${response.status} ${response.statusText})`;
+    try {
+        const text = await response.text();
+        if (!text) {
+            return fallback;
+        }
+        try {
+            const payload = JSON.parse(text);
+            if (typeof payload.message === "string") {
+                return `${payload.message} (${response.status})`;
+            }
+        } catch (_jsonError) {
+            return `${text.trim()} (${response.status})`;
+        }
+    } catch (_readError) {
+        return fallback;
+    }
+    return fallback;
+}
+
+function renderLatestRunBlock(result, repo) {
+    elements.workflowLink.href = WORKFLOW_PAGE(repo);
+
+    if (result.status === "rejected") {
+        elements.runsPanel.innerHTML = renderErrorBlock(
+            `Could not load workflow runs. ${escapeHtml(formatError(result.reason))}`,
+        );
+        return;
+    }
+
+    const runs = result.value.runs;
+    if (!runs.length) {
+        elements.runsPanel.innerHTML = renderEmptyState("No workflow runs are visible for this workflow yet.");
+        return;
+    }
+
+    const rows = runs
+        .map((run) => {
+            const tone = workflowTone(run);
+            return `
+                <tr>
+                    <td>
+                        <a class="text-link mono" href="${escapeAttribute(run.html_url)}" target="_blank" rel="noreferrer">
+                            #${escapeHtml(String(run.run_number || "—"))}
+                        </a>
+                    </td>
+                    <td>${badgeHtml(workflowLabel(run), tone)}</td>
+                    <td>${escapeHtml(run.event || "unknown")}</td>
+                    <td>${escapeHtml(run.display_title || "Brief Live Refresh")}</td>
+                    <td>${escapeHtml(run.actor?.login || "unknown")}</td>
+                    <td class="mono">${escapeHtml(run.head_branch || "main")}</td>
+                    <td>${escapeHtml(formatDateTime(run.updated_at))}<div class="muted">${escapeHtml(relativeTime(run.updated_at))}</div></td>
+                </tr>
+            `;
+        })
+        .join("");
+
+    elements.runsPanel.innerHTML = `
+        <table>
+            <thead>
+                <tr>
+                    <th>Run</th>
+                    <th>Status</th>
+                    <th>Trigger</th>
+                    <th>Title</th>
+                    <th>Actor</th>
+                    <th>Branch</th>
+                    <th>Updated</th>
+                </tr>
+            </thead>
+            <tbody>${rows}</tbody>
+        </table>
+    `;
+}
+
+function renderPublishedBlock(result, repo, season) {
+    const rollingUrl = `https://github.com/${repo}/releases/tag/brief-artifacts-${season}`;
+    elements.rollingReleaseLink.href = rollingUrl;
+
+    if (result.status === "rejected") {
+        const message = `Could not load the rolling release for ${season}. ${escapeHtml(formatError(result.reason))}`;
+        elements.publishedSummaryPanel.innerHTML = renderErrorBlock(message);
+        elements.assetPanel.innerHTML = renderEmptyState("Published asset links will appear once the rolling release is readable.");
+        return;
+    }
+
+    const { release, summary } = result.value;
+    if (!summary) {
+        elements.publishedSummaryPanel.innerHTML = renderEmptyState(
+            "The rolling release exists, but the published summary JSON is missing.",
+        );
+    } else {
+        const artifactSetId = summary.artifact_contract?.artifact_set_id || "unknown";
+        const archiveTag = artifactSetId === "unknown" ? null : `brief-artifacts-archive-${artifactSetId}`;
+        const archiveUrl = archiveTag ? `https://github.com/${repo}/releases/tag/${archiveTag}` : null;
+        const warnings = Array.isArray(summary.warnings) ? summary.warnings : [];
+        const validation = summary.validation || {};
+        const enrichment = summary.enrichment_contract || {};
+        const teams = Array.isArray(summary.teams) ? summary.teams.join(" vs ") : "unknown";
+
+        elements.publishedSummaryPanel.innerHTML = `
+            <div class="message-block">
+                <div class="button-row">
+                    ${badgeHtml(`artifact set ${artifactSetId}`, "info")}
+                    ${badgeHtml(freshnessLabel(summary.generated_at), freshnessTone(summary.generated_at))}
+                    ${badgeHtml(summary.artifact_contract?.publishable ? "publishable" : "non-publishable", summary.artifact_contract?.publishable ? "success" : "warning")}
+                </div>
+                <div class="kv">
+                    ${kvRow("Generated", `${formatDateTime(summary.generated_at)} (${relativeTime(summary.generated_at)})`)}
+                    ${kvRow("Teams", teams)}
+                    ${kvRow("Verification", `${validation.verification_fail_count ?? "?"} fail / ${validation.verification_warning_count ?? "?"} warn`)}
+                    ${kvRow("Enrichment", enrichment.artifact_status || "unknown")}
+                    ${kvRow("Smoke brief", booleanLabel(validation.smoke_brief_passed))}
+                </div>
+            </div>
+            <div class="message-block">
+                <h3>Release posture</h3>
+                <ul class="list">
+                    <li>Rolling release is the current last-known-good source for consumer defaults.</li>
+                    <li>Archive release preserves one immutable publishable run for rollback.</li>
+                    <li>${warnings.length ? `${warnings.length} warning(s) are recorded in the published summary.` : "No warnings are recorded in the published summary."}</li>
+                </ul>
+                <div class="asset-actions">
+                    <a class="button secondary" href="${escapeAttribute(release.html_url || rollingUrl)}" target="_blank" rel="noreferrer">Rolling release</a>
+                    ${
+                        archiveUrl
+                            ? `<a class="button ghost" href="${escapeAttribute(archiveUrl)}" target="_blank" rel="noreferrer">Archive release</a>`
+                            : ""
+                    }
+                </div>
+            </div>
+            ${
+                warnings.length
+                    ? `
+                        <div class="message-block warning">
+                            <h3>Published warnings</h3>
+                            <ul class="list">${warnings.map((warning) => `<li>${escapeHtml(warning)}</li>`).join("")}</ul>
+                        </div>
+                    `
+                    : ""
+            }
+        `;
+    }
+
+    const assets = Array.isArray(release.assets) ? release.assets : [];
+    if (!assets.length) {
+        elements.assetPanel.innerHTML = renderEmptyState("No release assets are attached to the rolling release.");
+        return;
+    }
+
+    elements.assetPanel.innerHTML = assets
+        .map((asset) => {
+            const label = assetLabel(asset.name);
+            return `
+                <article class="asset-card">
+                    <h3>${escapeHtml(label)}</h3>
+                    <p class="muted mono">${escapeHtml(asset.name)}</p>
+                    <div class="asset-actions">
+                        <a class="button secondary" href="${escapeAttribute(asset.browser_download_url || release.html_url)}" target="_blank" rel="noreferrer">Download</a>
+                        <a class="button ghost" href="${escapeAttribute(release.html_url || rollingUrl)}" target="_blank" rel="noreferrer">Open release</a>
+                    </div>
+                </article>
+            `;
+        })
+        .join("");
+}
+
+function renderOverviewCards(runsResult, publishedResult, repo, season) {
+    refreshQuickLinks();
+
+    if (runsResult.status === "fulfilled" && runsResult.value.runs.length) {
+        const latestRun = runsResult.value.runs[0];
+        elements.latestRunCard.innerHTML = `
+            <div class="metric-title">Latest workflow run</div>
+            <div class="metric-value">${escapeHtml(workflowLabel(latestRun))}</div>
+            <div class="metric-subtitle">${escapeHtml(latestRun.display_title || "Brief Live Refresh")}</div>
+            <div>${badgeHtml(latestRun.event || "unknown", "info")} ${badgeHtml(relativeTime(latestRun.updated_at), workflowTone(latestRun))}</div>
+            <div class="kv">
+                ${kvRow("Updated", formatDateTime(latestRun.updated_at))}
+                ${kvRow("Actor", latestRun.actor?.login || "unknown")}
+                ${kvRow("Branch", latestRun.head_branch || "main")}
+            </div>
+        `;
+    } else {
+        elements.latestRunCard.innerHTML = renderMetricFallback(
+            "Latest workflow run",
+            "Unavailable",
+            runsResult.status === "rejected"
+                ? formatError(runsResult.reason)
+                : "No runs are visible yet.",
+        );
+    }
+
+    if (publishedResult.status === "fulfilled" && publishedResult.value.summary) {
+        const summary = publishedResult.value.summary;
+        const artifactSetId = summary.artifact_contract?.artifact_set_id || "unknown";
+        elements.publishedCard.innerHTML = `
+            <div class="metric-title">Published last-known-good</div>
+            <div class="metric-value mono">${escapeHtml(artifactSetId)}</div>
+            <div class="metric-subtitle">Rolling release for season ${escapeHtml(String(season))}</div>
+            <div>${badgeHtml(summary.artifact_contract?.publishable ? "publishable" : "non-publishable", summary.artifact_contract?.publishable ? "success" : "warning")}</div>
+            <div class="kv">
+                ${kvRow("Generated", formatDateTime(summary.generated_at))}
+                ${kvRow("Verification", `${summary.validation?.verification_fail_count ?? "?"} fail / ${summary.validation?.verification_warning_count ?? "?"} warn`)}
+                ${kvRow("Release", `<a class="text-link" href="${escapeAttribute(`https://github.com/${repo}/releases/tag/brief-artifacts-${season}`)}" target="_blank" rel="noreferrer">brief-artifacts-${escapeHtml(String(season))}</a>`)}
+            </div>
+        `;
+    } else {
+        elements.publishedCard.innerHTML = renderMetricFallback(
+            "Published last-known-good",
+            "Unavailable",
+            publishedResult.status === "rejected"
+                ? formatError(publishedResult.reason)
+                : "No published summary asset was found.",
+        );
+    }
+
+    if (publishedResult.status === "fulfilled" && publishedResult.value.summary) {
+        const summary = publishedResult.value.summary;
+        elements.freshnessCard.innerHTML = `
+            <div class="metric-title">Freshness</div>
+            <div class="metric-value">${escapeHtml(freshnessLabel(summary.generated_at))}</div>
+            <div class="metric-subtitle">Based on pipeline summary \`generated_at\`</div>
+            <div>${badgeHtml(relativeTime(summary.generated_at), freshnessTone(summary.generated_at))}</div>
+            <div class="kv">
+                ${kvRow("Generated at", formatDateTime(summary.generated_at))}
+                ${kvRow("Policy", "warn > 36h / critical > 72h")}
+            </div>
+        `;
+    } else {
+        elements.freshnessCard.innerHTML = renderMetricFallback(
+            "Freshness",
+            "Unknown",
+            "Load a published summary to compute release freshness.",
+        );
+    }
+
+    elements.operatorNoteCard.innerHTML = renderOperatorNote(runsResult, publishedResult, repo, season);
+
+    const badges = [];
+    if (runsResult.status === "fulfilled" && runsResult.value.runs.length) {
+        badges.push(badgeHtml(workflowLabel(runsResult.value.runs[0]), workflowTone(runsResult.value.runs[0])));
+    } else {
+        badges.push(badgeHtml("workflow unknown", "neutral"));
+    }
+    if (publishedResult.status === "fulfilled" && publishedResult.value.summary) {
+        const summary = publishedResult.value.summary;
+        badges.push(badgeHtml(freshnessLabel(summary.generated_at), freshnessTone(summary.generated_at)));
+        badges.push(
+            badgeHtml(
+                summary.artifact_contract?.published_set_complete ? "published set complete" : "published set incomplete",
+                summary.artifact_contract?.published_set_complete ? "success" : "warning",
+            ),
+        );
+    } else {
+        badges.push(badgeHtml("published summary unavailable", "warning"));
+    }
+    elements.statusStrip.innerHTML = badges.join("");
+}
+
+function renderOperatorNote(runsResult, publishedResult, repo, season) {
+    const noteParts = [];
+
+    if (runsResult.status === "fulfilled" && runsResult.value.runs.length) {
+        const latestRun = runsResult.value.runs[0];
+        if (latestRun.status !== "completed") {
+            noteParts.push("A run is still in flight, so the rolling release remains the last-known-good source until publication finishes.");
+        } else if (latestRun.conclusion !== "success") {
+            noteParts.push("The latest workflow run is not healthy. Consumers should still trust the rolling release, not the newest failed run.");
+        } else {
+            noteParts.push("The latest workflow run is healthy. The rolling release should reflect the current last-known-good artifact set for this season.");
+        }
+    } else {
+        noteParts.push("Workflow data is unavailable, so treat the rolling release as the authoritative operator view.");
+    }
+
+    if (publishedResult.status === "fulfilled" && publishedResult.value.summary) {
+        const summary = publishedResult.value.summary;
+        const warnings = Array.isArray(summary.warnings) ? summary.warnings.length : 0;
+        if (warnings) {
+            noteParts.push(`The published summary still carries ${warnings} warning(s), so operators should check the warning list before treating the run as routine.`);
+        } else {
+            noteParts.push("The published summary has no recorded warnings.");
+        }
+    } else {
+        noteParts.push("The published summary could not be loaded. A token may be required if the repo or release is private.");
+    }
+
+    return `
+        <div class="metric-title">Operator note</div>
+        <div class="metric-value">Current vs last-known-good</div>
+        <div class="metric-subtitle">This page does not create its own state model.</div>
+        <div class="message-block">
+            <p>${escapeHtml(noteParts.join(" "))}</p>
+            <div class="asset-actions">
+                <a class="button secondary" href="${escapeAttribute(WORKFLOW_PAGE(repo))}" target="_blank" rel="noreferrer">Workflow page</a>
+                <a class="button ghost" href="${escapeAttribute(`https://github.com/${repo}/releases/tag/brief-artifacts-${season}`)}" target="_blank" rel="noreferrer">Rolling release</a>
+            </div>
+        </div>
+    `;
+}
+
+function refreshQuickLinks() {
+    const repo = normalizedRepo();
+    const season = normalizedSeason();
+    const rollingRelease = `https://github.com/${repo}/releases/tag/brief-artifacts-${season}`;
+    const links = [
+        {
+            title: "Workflow",
+            body: "Open the underlying GitHub Actions workflow and its manual dispatch UI.",
+            href: WORKFLOW_PAGE(repo),
+        },
+        {
+            title: "Rolling release",
+            body: "Inspect the current last-known-good published artifact set for this season.",
+            href: rollingRelease,
+        },
+        {
+            title: "All releases",
+            body: "See both rolling and archived artifact releases for rollback history.",
+            href: RELEASES_PAGE(repo),
+        },
+        {
+            title: "Runbook",
+            body: "Operator instructions for live refresh, publication, freshness, and rollback.",
+            href: RUNBOOK_PAGE(repo),
+        },
+        {
+            title: "Published contract",
+            body: "Machine-readable artifact expectations and the season release contract.",
+            href: CONTRACT_PAGE(repo),
+        },
+        {
+            title: "Alerts thread",
+            body: "Jump into the scheduled-run alert issue if the overnight job is unhealthy.",
+            href: ALERTS_PAGE(repo),
+        },
+    ];
+
+    elements.quickLinksPanel.innerHTML = links
+        .map(
+            (link) => `
+                <article class="link-card">
+                    <h3>${escapeHtml(link.title)}</h3>
+                    <p class="muted">${escapeHtml(link.body)}</p>
+                    <div class="link-actions">
+                        <a class="button ghost" href="${escapeAttribute(link.href)}" target="_blank" rel="noreferrer">Open</a>
+                    </div>
+                </article>
+            `,
+        )
+        .join("");
+}
+
+function renderMetricFallback(title, value, detail) {
+    return `
+        <div class="metric-title">${escapeHtml(title)}</div>
+        <div class="metric-value">${escapeHtml(value)}</div>
+        <div class="metric-subtitle">${escapeHtml(detail)}</div>
+    `;
+}
+
+function renderErrorBlock(message) {
+    return `<div class="message-block error"><p>${message}</p></div>`;
+}
+
+function renderEmptyState(message) {
+    return `<div class="empty-state"><p>${escapeHtml(message)}</p></div>`;
+}
+
+function kvRow(label, value) {
+    return `
+        <div class="kv-row">
+            <span class="kv-label">${escapeHtml(label)}</span>
+            <span class="kv-value">${value}</span>
+        </div>
+    `;
+}
+
+function badgeHtml(label, tone = "neutral") {
+    return `<span class="badge badge-${escapeAttribute(tone)}">${escapeHtml(label)}</span>`;
+}
+
+function booleanLabel(value) {
+    if (value === true) {
+        return "true";
+    }
+    if (value === false) {
+        return "false";
+    }
+    return "unknown";
+}
+
+function workflowLabel(run) {
+    if (run.status !== "completed") {
+        return run.status || "in_progress";
+    }
+    return run.conclusion || "completed";
+}
+
+function workflowTone(run) {
+    if (run.status !== "completed") {
+        return "info";
+    }
+    if (run.conclusion === "success") {
+        return "success";
+    }
+    if (run.conclusion === "cancelled" || run.conclusion === "skipped") {
+        return "warning";
+    }
+    return "danger";
+}
+
+function freshnessLabel(timestamp) {
+    const status = freshnessTone(timestamp);
+    if (status === "success") {
+        return "fresh";
+    }
+    if (status === "warning") {
+        return "stale warning";
+    }
+    if (status === "danger") {
+        return "stale critical";
+    }
+    return "unknown";
+}
+
+function freshnessTone(timestamp) {
+    const generatedAt = timestamp ? new Date(timestamp) : null;
+    if (!generatedAt || Number.isNaN(generatedAt.getTime())) {
+        return "neutral";
+    }
+    const ageHours = (Date.now() - generatedAt.getTime()) / 3600000;
+    if (ageHours <= 36) {
+        return "success";
+    }
+    if (ageHours <= 72) {
+        return "warning";
+    }
+    return "danger";
+}
+
+function assetLabel(filename) {
+    if (filename.startsWith("pbp_stats_bundle_")) {
+        return "Bundle";
+    }
+    if (filename.startsWith("cfbstats_verification_")) {
+        return "Verification report";
+    }
+    if (filename.startsWith("cfbstats_")) {
+        return "CFBStats snapshot";
+    }
+    if (filename.startsWith("game_prep_pipeline_summary_")) {
+        return "Pipeline summary";
+    }
+    return filename;
+}
+
+function normalizedRepo() {
+    return (elements.repoInput.value.trim() || DEFAULTS.repo).replace(/^https:\/\/github\.com\//, "").replace(/\/+$/, "");
+}
+
+function normalizedSeason() {
+    return elements.seasonInput.value.trim() || DEFAULTS.season;
+}
+
+function setLoadingState(isLoading) {
+    loading = isLoading;
+    syncActionButtons();
+    if (isLoading) {
+        elements.statusStrip.innerHTML = badgeHtml("Refreshing dashboard…", "neutral");
+    }
+}
+
+function syncActionButtons() {
+    elements.refreshButton.disabled = loading;
+    elements.dispatchButton.disabled = loading || !elements.tokenInput.value.trim();
+}
+
+function setInlineMessage(target, message, tone = "neutral") {
+    target.innerHTML = message
+        ? `<div class="message-block ${escapeAttribute(tone)}"><p>${escapeHtml(message)}</p></div>`
+        : "";
+}
+
+function formatDateTime(timestamp) {
+    if (!timestamp) {
+        return "unknown";
+    }
+    const date = new Date(timestamp);
+    if (Number.isNaN(date.getTime())) {
+        return String(timestamp);
+    }
+    return new Intl.DateTimeFormat(undefined, {
+        dateStyle: "medium",
+        timeStyle: "short",
+    }).format(date);
+}
+
+function relativeTime(timestamp) {
+    if (!timestamp) {
+        return "unknown";
+    }
+    const date = new Date(timestamp);
+    if (Number.isNaN(date.getTime())) {
+        return "unknown";
+    }
+    const deltaSeconds = Math.round((date.getTime() - Date.now()) / 1000);
+    const units = [
+        ["day", 86400],
+        ["hour", 3600],
+        ["minute", 60],
+    ];
+    for (const [unit, size] of units) {
+        if (Math.abs(deltaSeconds) >= size || unit === "minute") {
+            return new Intl.RelativeTimeFormat(undefined, { numeric: "auto" }).format(
+                Math.round(deltaSeconds / size),
+                unit,
+            );
+        }
+    }
+    return "just now";
+}
+
+function formatError(error) {
+    if (!error) {
+        return "Unknown error.";
+    }
+    if (error instanceof Error) {
+        return error.message;
+    }
+    return String(error);
+}
+
+function encodeRepo(repo) {
+    return repo
+        .split("/")
+        .map((part) => encodeURIComponent(part))
+        .join("/");
+}
+
+function loadJsonStorage(key) {
+    const raw = localStorage.getItem(key);
+    if (!raw) {
+        return null;
+    }
+    try {
+        return JSON.parse(raw);
+    } catch (_error) {
+        return null;
+    }
+}
+
+function escapeHtml(value) {
+    return String(value)
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;")
+        .replaceAll("'", "&#39;");
+}
+
+function escapeAttribute(value) {
+    return escapeHtml(value);
+}

--- a/operator/index.html
+++ b/operator/index.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Brief Pipeline Operator Dashboard</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+        href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;700&display=swap"
+        rel="stylesheet"
+    >
+    <link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+    <main class="shell">
+        <header class="hero panel">
+            <div class="eyebrow">Operator Dashboard MVP</div>
+            <div class="hero-grid">
+                <div>
+                    <h1>Brief Refresh Control Plane</h1>
+                    <p class="hero-copy">
+                        Launch the live refresh workflow, inspect the newest run, and verify the
+                        published last-known-good artifact set without leaving one page.
+                    </p>
+                </div>
+                <div class="hero-aside">
+                    <p class="hero-note">
+                        The dashboard stays thin on purpose: GitHub Actions runs the pipeline,
+                        GitHub Releases hold the published artifacts, and the summary JSON stays
+                        the machine-readable source of truth.
+                    </p>
+                </div>
+            </div>
+            <div id="statusStrip" class="status-strip">
+                <span class="badge badge-neutral">Loading dashboard…</span>
+            </div>
+        </header>
+
+        <section class="panel-grid">
+            <section class="panel">
+                <div class="section-heading">
+                    <div>
+                        <div class="eyebrow">Connection</div>
+                        <h2>GitHub Access</h2>
+                    </div>
+                </div>
+                <form id="settingsForm" class="stack">
+                    <label class="field">
+                        <span>Repository</span>
+                        <input id="repoInput" name="repo" type="text" value="victorres11/pbp-analysis" autocomplete="off">
+                    </label>
+                    <label class="field">
+                        <span>GitHub token</span>
+                        <input id="tokenInput" name="token" type="password" placeholder="Optional for public reads, required for dispatch/private data" autocomplete="off">
+                    </label>
+                    <div class="button-row">
+                        <button id="saveTokenButton" class="button secondary" type="button">Save token locally</button>
+                        <button id="clearTokenButton" class="button ghost" type="button">Clear token</button>
+                        <button id="refreshButton" class="button primary" type="button">Refresh dashboard</button>
+                    </div>
+                    <p class="field-help">
+                        The token never leaves your browser except in direct calls to GitHub’s API.
+                        Dispatch and private workflow data require auth. A classic `repo` token is
+                        the simplest operator path today.
+                    </p>
+                </form>
+                <div id="settingsMessage" class="inline-message"></div>
+            </section>
+
+            <section class="panel">
+                <div class="section-heading">
+                    <div>
+                        <div class="eyebrow">Launch</div>
+                        <h2>Run Live Refresh</h2>
+                    </div>
+                    <span class="badge badge-info">Dispatches `brief-live-refresh.yml` on `main`</span>
+                </div>
+                <form id="dispatchForm" class="stack">
+                    <div class="field-grid two-up">
+                        <label class="field">
+                            <span>Team 1</span>
+                            <input id="team1Input" name="team1" type="text" value="Washington" autocomplete="off">
+                        </label>
+                        <label class="field">
+                            <span>Team 2</span>
+                            <input id="team2Input" name="team2" type="text" value="Ohio State" autocomplete="off">
+                        </label>
+                    </div>
+                    <div class="field-grid three-up">
+                        <label class="field">
+                            <span>Season</span>
+                            <input id="seasonInput" name="season" type="number" min="2025" step="1" value="2025">
+                        </label>
+                        <label class="field">
+                            <span>Last-N</span>
+                            <input id="lastNInput" name="last_n" type="number" min="1" step="1" value="3">
+                        </label>
+                        <label class="field">
+                            <span>Brief format</span>
+                            <select id="briefFormatInput" name="brief_format">
+                                <option value="markdown">markdown</option>
+                                <option value="html">html</option>
+                                <option value="both">both</option>
+                            </select>
+                        </label>
+                    </div>
+                    <div class="toggle-grid">
+                        <label class="toggle">
+                            <input id="runTestsInput" name="run_tests" type="checkbox">
+                            <span>Run parser + analysis tests</span>
+                        </label>
+                        <label class="toggle">
+                            <input id="strictVerificationInput" name="strict_verification" type="checkbox" checked>
+                            <span>Fail on verification `fail` metrics</span>
+                        </label>
+                        <label class="toggle">
+                            <input id="includeEnrichmentInput" name="include_enrichment" type="checkbox" checked>
+                            <span>Refresh enrichment and require it</span>
+                        </label>
+                    </div>
+                    <div class="button-row">
+                        <button id="dispatchButton" class="button primary" type="submit">Run refresh</button>
+                    </div>
+                    <p class="field-help">
+                        If the latest run fails, the rolling release stays on the last-known-good
+                        artifact set. This page is just the control surface.
+                    </p>
+                </form>
+                <div id="dispatchMessage" class="inline-message"></div>
+            </section>
+        </section>
+
+        <section class="metric-grid">
+            <article id="latestRunCard" class="panel metric-card"></article>
+            <article id="publishedCard" class="panel metric-card"></article>
+            <article id="freshnessCard" class="panel metric-card"></article>
+            <article id="operatorNoteCard" class="panel metric-card"></article>
+        </section>
+
+        <section class="panel">
+            <div class="section-heading">
+                <div>
+                    <div class="eyebrow">Current</div>
+                    <h2>Recent Workflow Runs</h2>
+                </div>
+                <a
+                    id="workflowLink"
+                    class="text-link"
+                    href="https://github.com/victorres11/pbp-analysis/actions/workflows/brief-live-refresh.yml"
+                    target="_blank"
+                    rel="noreferrer"
+                >Open workflow</a>
+            </div>
+            <div id="runsPanel" class="table-wrap"></div>
+        </section>
+
+        <section class="panel-grid">
+            <section class="panel">
+                <div class="section-heading">
+                    <div>
+                        <div class="eyebrow">Last-known-good</div>
+                        <h2>Published Season Summary</h2>
+                    </div>
+                    <a
+                        id="rollingReleaseLink"
+                        class="text-link"
+                        href="https://github.com/victorres11/pbp-analysis/releases"
+                        target="_blank"
+                        rel="noreferrer"
+                    >Open rolling release</a>
+                </div>
+                <div id="publishedSummaryPanel" class="stack"></div>
+            </section>
+
+            <section class="panel">
+                <div class="section-heading">
+                    <div>
+                        <div class="eyebrow">Artifacts</div>
+                        <h2>Published Asset Links</h2>
+                    </div>
+                </div>
+                <div id="assetPanel" class="asset-grid"></div>
+            </section>
+        </section>
+
+        <section class="panel">
+            <div class="section-heading">
+                <div>
+                    <div class="eyebrow">Shortcuts</div>
+                    <h2>Operator Links</h2>
+                </div>
+            </div>
+            <div id="quickLinksPanel" class="link-grid"></div>
+        </section>
+    </main>
+
+    <template id="emptyStateTemplate">
+        <div class="empty-state">
+            <p>Nothing to show yet.</p>
+        </div>
+    </template>
+
+    <script src="./app.js"></script>
+</body>
+</html>

--- a/operator/styles.css
+++ b/operator/styles.css
@@ -1,0 +1,509 @@
+:root {
+    --bg: #06111a;
+    --panel: rgba(11, 22, 33, 0.82);
+    --panel-strong: rgba(14, 28, 42, 0.94);
+    --border: rgba(255, 255, 255, 0.08);
+    --text: #f4f7fb;
+    --muted: #9db0c4;
+    --accent: #5eead4;
+    --accent-2: #f59e0b;
+    --danger: #f87171;
+    --warning: #fbbf24;
+    --success: #4ade80;
+    --info: #7dd3fc;
+    --shadow: 0 24px 70px rgba(0, 0, 0, 0.32);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html, body {
+    margin: 0;
+    min-height: 100%;
+}
+
+body {
+    font-family: "Space Grotesk", system-ui, sans-serif;
+    background:
+        radial-gradient(circle at top left, rgba(94, 234, 212, 0.18), transparent 30%),
+        radial-gradient(circle at top right, rgba(245, 158, 11, 0.18), transparent 26%),
+        linear-gradient(180deg, #08131d 0%, #040a10 100%);
+    color: var(--text);
+    line-height: 1.5;
+}
+
+a {
+    color: inherit;
+}
+
+.shell {
+    width: min(1280px, calc(100vw - 2rem));
+    margin: 0 auto;
+    padding: 1.2rem 0 3rem;
+}
+
+.panel {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 24px;
+    box-shadow: var(--shadow);
+    backdrop-filter: blur(14px);
+}
+
+.hero {
+    padding: 1.5rem;
+    margin-bottom: 1rem;
+    background:
+        linear-gradient(135deg, rgba(94, 234, 212, 0.12), transparent 45%),
+        linear-gradient(315deg, rgba(245, 158, 11, 0.14), transparent 40%),
+        var(--panel-strong);
+}
+
+.hero-grid {
+    display: grid;
+    grid-template-columns: 2.1fr 1fr;
+    gap: 1.5rem;
+    align-items: start;
+}
+
+.eyebrow {
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin-bottom: 0.55rem;
+}
+
+h1, h2, h3, p {
+    margin: 0;
+}
+
+h1 {
+    font-size: clamp(2rem, 3vw, 3rem);
+    line-height: 1.05;
+    margin-bottom: 0.8rem;
+}
+
+h2 {
+    font-size: 1.15rem;
+}
+
+.hero-copy {
+    max-width: 42rem;
+    color: #d7e4ef;
+    font-size: 1rem;
+}
+
+.hero-aside {
+    padding: 1rem 1.1rem;
+    border-radius: 18px;
+    border: 1px solid rgba(125, 211, 252, 0.16);
+    background: rgba(4, 12, 20, 0.46);
+}
+
+.hero-note,
+.field-help,
+.muted {
+    color: var(--muted);
+}
+
+.status-strip {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem;
+    margin-top: 1.25rem;
+}
+
+.panel-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+    margin-top: 1rem;
+}
+
+.metric-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 1rem;
+    margin-top: 1rem;
+}
+
+.metric-card,
+.panel > .section-heading,
+.panel > .stack,
+.panel > .table-wrap,
+.panel > .asset-grid,
+.panel > .link-grid {
+    padding: 1.15rem 1.2rem;
+}
+
+.metric-card {
+    min-height: 220px;
+}
+
+.section-heading {
+    display: flex;
+    align-items: start;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.stack {
+    display: grid;
+    gap: 0.95rem;
+}
+
+.field-grid {
+    display: grid;
+    gap: 0.85rem;
+}
+
+.field-grid.two-up {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.field-grid.three-up {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.field {
+    display: grid;
+    gap: 0.45rem;
+}
+
+.field span,
+.toggle span {
+    font-size: 0.88rem;
+    color: #dce7f0;
+}
+
+input,
+select,
+button {
+    font: inherit;
+}
+
+input[type="text"],
+input[type="password"],
+input[type="number"],
+select {
+    width: 100%;
+    border-radius: 14px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(4, 12, 20, 0.72);
+    color: var(--text);
+    padding: 0.82rem 0.95rem;
+    outline: none;
+    transition: border-color 0.15s ease, transform 0.15s ease;
+}
+
+input:focus,
+select:focus {
+    border-color: rgba(94, 234, 212, 0.6);
+    transform: translateY(-1px);
+}
+
+.button-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.7rem;
+}
+
+.button {
+    border: 0;
+    border-radius: 999px;
+    padding: 0.78rem 1.2rem;
+    cursor: pointer;
+    font-weight: 700;
+    transition: transform 0.15s ease, opacity 0.15s ease, background 0.15s ease;
+}
+
+.button:hover {
+    transform: translateY(-1px);
+}
+
+.button:disabled {
+    opacity: 0.58;
+    cursor: not-allowed;
+    transform: none;
+}
+
+.button.primary {
+    background: linear-gradient(135deg, var(--accent), #3b82f6);
+    color: #041017;
+}
+
+.button.secondary {
+    background: rgba(125, 211, 252, 0.16);
+    color: #dff6ff;
+    border: 1px solid rgba(125, 211, 252, 0.24);
+}
+
+.button.ghost {
+    background: rgba(255, 255, 255, 0.04);
+    color: #eef5fa;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.toggle-grid {
+    display: grid;
+    gap: 0.75rem;
+}
+
+.toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.8rem 0.95rem;
+    border-radius: 16px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.035);
+}
+
+.toggle input {
+    width: 1.05rem;
+    height: 1.05rem;
+    accent-color: var(--accent);
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    border-radius: 999px;
+    padding: 0.36rem 0.7rem;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    border: 1px solid transparent;
+}
+
+.badge-success {
+    background: rgba(74, 222, 128, 0.14);
+    color: #bbf7d0;
+    border-color: rgba(74, 222, 128, 0.28);
+}
+
+.badge-warning {
+    background: rgba(251, 191, 36, 0.14);
+    color: #fde68a;
+    border-color: rgba(251, 191, 36, 0.28);
+}
+
+.badge-danger {
+    background: rgba(248, 113, 113, 0.16);
+    color: #fecaca;
+    border-color: rgba(248, 113, 113, 0.32);
+}
+
+.badge-info {
+    background: rgba(125, 211, 252, 0.12);
+    color: #bae6fd;
+    border-color: rgba(125, 211, 252, 0.22);
+}
+
+.badge-neutral {
+    background: rgba(255, 255, 255, 0.06);
+    color: #d7e4ef;
+    border-color: rgba(255, 255, 255, 0.12);
+}
+
+.inline-message {
+    min-height: 1.2rem;
+    padding: 0 1.2rem 1.15rem;
+    color: var(--muted);
+}
+
+.message-block {
+    border-radius: 16px;
+    padding: 0.9rem 1rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.04);
+}
+
+.message-block.success {
+    border-color: rgba(74, 222, 128, 0.25);
+    background: rgba(74, 222, 128, 0.09);
+}
+
+.message-block.warning {
+    border-color: rgba(251, 191, 36, 0.25);
+    background: rgba(251, 191, 36, 0.09);
+}
+
+.message-block.error {
+    border-color: rgba(248, 113, 113, 0.28);
+    background: rgba(248, 113, 113, 0.1);
+}
+
+.metric-title {
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--muted);
+    margin-bottom: 0.8rem;
+}
+
+.metric-value {
+    font-size: clamp(1.45rem, 2vw, 2rem);
+    font-weight: 700;
+    line-height: 1.1;
+    margin-bottom: 0.45rem;
+}
+
+.metric-subtitle {
+    color: var(--muted);
+    margin-bottom: 0.95rem;
+}
+
+.kv {
+    display: grid;
+    gap: 0.4rem;
+    margin-top: 0.8rem;
+}
+
+.kv-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.42rem 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    font-size: 0.92rem;
+}
+
+.kv-row:last-child {
+    border-bottom: 0;
+}
+
+.kv-label {
+    color: var(--muted);
+}
+
+.kv-value,
+.mono {
+    font-family: "IBM Plex Mono", ui-monospace, monospace;
+}
+
+.table-wrap {
+    overflow-x: auto;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+th,
+td {
+    text-align: left;
+    padding: 0.78rem 0.72rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+    vertical-align: top;
+}
+
+th {
+    color: var(--muted);
+    font-size: 0.76rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+tbody tr:hover {
+    background: rgba(255, 255, 255, 0.03);
+}
+
+.asset-grid,
+.link-grid {
+    display: grid;
+    gap: 0.85rem;
+}
+
+.asset-card,
+.link-card {
+    border-radius: 18px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.04);
+    padding: 0.95rem 1rem;
+}
+
+.asset-card h3,
+.link-card h3 {
+    font-size: 1rem;
+    margin-bottom: 0.35rem;
+}
+
+.asset-actions,
+.link-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.55rem;
+    margin-top: 0.8rem;
+}
+
+.text-link {
+    color: #c7f9f2;
+    text-decoration: none;
+}
+
+.text-link:hover {
+    text-decoration: underline;
+}
+
+.empty-state {
+    color: var(--muted);
+    border: 1px dashed rgba(255, 255, 255, 0.12);
+    border-radius: 18px;
+    padding: 1rem;
+}
+
+.list {
+    display: grid;
+    gap: 0.55rem;
+    margin: 0;
+    padding-left: 1.15rem;
+}
+
+.list li {
+    color: #dce7f0;
+}
+
+@media (max-width: 1100px) {
+    .metric-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .hero-grid,
+    .panel-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 720px) {
+    .shell {
+        width: min(100vw - 1rem, 100%);
+        padding-top: 0.75rem;
+    }
+
+    .hero,
+    .metric-card,
+    .panel > .section-heading,
+    .panel > .stack,
+    .panel > .table-wrap,
+    .panel > .asset-grid,
+    .panel > .link-grid {
+        padding-left: 1rem;
+        padding-right: 1rem;
+    }
+
+    .field-grid.two-up,
+    .field-grid.three-up,
+    .metric-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .button-row {
+        flex-direction: column;
+    }
+}


### PR DESCRIPTION
## Summary
- add a static `/operator/` dashboard that reads workflow runs and rolling release state directly from GitHub
- support token-backed `workflow_dispatch` launches for `brief-live-refresh.yml` without introducing a new backend
- document the operator route, token expectations, and thin-control-plane contract in the README and runbook

## Dashboard shape
This MVP stays intentionally thin:
- GitHub Actions remains the execution engine for live refresh
- GitHub Releases remain the publication target for the rolling `brief-artifacts-<season>` set
- the published `game_prep_pipeline_summary_<season>.json` remains the machine-readable source of truth

The page surfaces:
- GitHub auth/token handling stored locally in the browser only when the operator explicitly saves it
- live refresh dispatch controls for matchup, season, last-N, format, tests, strict verification, and enrichment
- latest workflow run + recent run list
- rolling last-known-good release summary, freshness, validation counts, warnings, and asset links
- quick links to the workflow, releases, runbook, published contract, and alert issue thread

## Why this shape
Issue #219 is about giving operators a UI without creating a second pipeline state model. This implementation keeps that boundary clean: the dashboard is a control plane over the existing workflow/release contracts, not a new service that has to be kept in sync.

## Validation
- `node --check operator/app.js`
- `git diff --check`
