### PR TITLE
Align enrichment API requests with yr-data-api

### DIFF
--- a/scripts/game_prep_brief/loaders.py
+++ b/scripts/game_prep_brief/loaders.py
@@ -2265,10 +2265,10 @@ def _fetch_negative_play_stats(team_slug: str, team_name: str | None = None) -> 
     reasons: list[str] = []
 
     endpoint_specs = [
-        ("negative_plays_pg_api", "pbp/negative-plays?scope=season&format=text"),
-        ("negative_plays_forced_pg_api", "pbp/negative-plays-forced?scope=season&format=text"),
-        ("negative_plays_pg_last3_api", "pbp/negative-plays?scope=last3&format=text"),
-        ("negative_plays_forced_pg_last3_api", "pbp/negative-plays-forced?scope=last3&format=text"),
+        ("negative_plays_pg_api", "pbp/negative-plays?side=off&scope=season&format=text"),
+        ("negative_plays_forced_pg_api", "pbp/negative-plays?side=def&scope=season&format=text"),
+        ("negative_plays_pg_last3_api", "pbp/negative-plays?side=off&scope=last3&format=text"),
+        ("negative_plays_forced_pg_last3_api", "pbp/negative-plays?side=def&scope=last3&format=text"),
     ]
 
     for key, suffix in endpoint_specs:
@@ -2320,16 +2320,19 @@ def _fetch_pff_snapshot(team_slug: str, team_name: str | None = None) -> tuple[d
     def _try_fetch(suffix: str) -> dict[str, object]:
         return _fetch_text_result_from_candidates(candidates, suffix)
 
-    plays_result = _try_fetch("pff/plays?side=both&format=text")
-    plays = plays_result.get("text")
-    if plays and "," in str(plays):
-        off, deff = str(plays).split(",", 1)
-        out["pff_plays_offense_pg"] = off.strip() or "N/A"
-        out["pff_plays_defense_pg"] = deff.strip() or "N/A"
-    elif plays:
-        reasons.append("pff_plays:malformed_payload")
+    plays_off_result = _try_fetch("pff/plays?side=off&format=text")
+    plays_off = plays_off_result.get("text")
+    if plays_off:
+        out["pff_plays_offense_pg"] = str(plays_off).strip() or "N/A"
     else:
-        reasons.append(f"pff_plays:{plays_result.get('reason') or 'unavailable'}")
+        reasons.append(f"pff_plays_off:{plays_off_result.get('reason') or 'unavailable'}")
+
+    plays_def_result = _try_fetch("pff/plays?side=def&format=text")
+    plays_def = plays_def_result.get("text")
+    if plays_def:
+        out["pff_plays_defense_pg"] = str(plays_def).strip() or "N/A"
+    else:
+        reasons.append(f"pff_plays_def:{plays_def_result.get('reason') or 'unavailable'}")
 
     tackling_result = _try_fetch("pff/tackling-per-game?format=text")
     tackling_pg = tackling_result.get("text")

--- a/tests/test_enrichment_provider_contract.py
+++ b/tests/test_enrichment_provider_contract.py
@@ -12,9 +12,13 @@ PIPELINE_FIXTURES = ROOT / "tests" / "fixtures" / "pipeline"
 
 
 def test_fetch_pff_snapshot_treats_zero_placeholder_as_partial_provider(monkeypatch) -> None:
+    seen_suffixes: list[str] = []
+
     def _fake_fetch(_candidates: list[str], suffix: str, **_kwargs) -> dict[str, object]:
+        seen_suffixes.append(suffix)
         payloads = {
-            "pff/plays?side=both&format=text": "70,68",
+            "pff/plays?side=off&format=text": "70",
+            "pff/plays?side=def&format=text": "68",
             "pff/tackling-per-game?format=text": "0\t0\t0",
             "pff/sacks-allowed?format=text": "1.4",
             "pff/fmt?format=text": "11\t1.2",
@@ -35,6 +39,43 @@ def test_fetch_pff_snapshot_treats_zero_placeholder_as_partial_provider(monkeypa
     assert values["pff_hurry_up_pct"] == "27.0%"
     assert provider["status"] == "partial"
     assert "pff_tackling:zero_placeholder_response" in provider["reasons"]
+    assert seen_suffixes[:2] == [
+        "pff/plays?side=off&format=text",
+        "pff/plays?side=def&format=text",
+    ]
+
+
+def test_fetch_negative_play_stats_uses_supported_side_parameters(monkeypatch) -> None:
+    seen_suffixes: list[str] = []
+
+    def _fake_fetch(_candidates: list[str], suffix: str, **_kwargs) -> dict[str, object]:
+        seen_suffixes.append(suffix)
+        payloads = {
+            "pbp/negative-plays?side=off&scope=season&format=text": "6.3",
+            "pbp/negative-plays?side=def&scope=season&format=text": "7.1",
+            "pbp/negative-plays?side=off&scope=last3&format=text": "5.0",
+            "pbp/negative-plays?side=def&scope=last3&format=text": "8.0",
+        }
+        text = payloads.get(suffix)
+        return {"text": text, "status": "ok" if text else "unavailable", "reason": None, "url": suffix}
+
+    monkeypatch.setattr(loaders, "_fetch_text_result_from_candidates", _fake_fetch)
+
+    values, provider = loaders._fetch_negative_play_stats("ucla", team_name="UCLA")
+
+    assert values == {
+        "negative_plays_pg_api": "6.3",
+        "negative_plays_forced_pg_api": "7.1",
+        "negative_plays_pg_last3_api": "5.0",
+        "negative_plays_forced_pg_last3_api": "8.0",
+    }
+    assert provider["status"] == "ok"
+    assert seen_suffixes == [
+        "pbp/negative-plays?side=off&scope=season&format=text",
+        "pbp/negative-plays?side=def&scope=season&format=text",
+        "pbp/negative-plays?side=off&scope=last3&format=text",
+        "pbp/negative-plays?side=def&scope=last3&format=text",
+    ]
 
 
 def test_merge_enrichment_payload_preserves_prior_values_and_failure_metadata() -> None:


### PR DESCRIPTION
## Summary
- align enrichment negative-play requests with the existing `yr-data-api` `pbp/negative-plays?side=off|def` contract
- replace the unsupported `pff/plays?side=both` request with separate `side=off` and `side=def` calls
- add regression coverage around the exact suffixes so the brief client does not drift away from the live API again

## Why this fixes the UCLA/USC failure
The UCLA/USC brief was not failing because those teams lacked data. The brief client had drifted from the live API contract:
- it requested `pbp/negative-plays-forced`, but `yr-data-api` exposes forced negative plays via `pbp/negative-plays?side=def`
- it requested `pff/plays?side=both`, but the API only accepts `side=off` or `side=def`

That contract drift produced the 404/422 warnings during `--refresh-enrichment` and made the one-button path feel unreliable.

## Validation
- `PYTHONPATH=. /Users/victorres/projects2/pbp/.venv/bin/python -m pytest -q tests/test_enrichment_provider_contract.py tests/test_game_prep_cli_enrichment.py`
- `./scripts/run-game-prep-brief.sh "UCLA" "USC" --season 2025 --format both --refresh-enrichment`

The real UCLA/USC run now completes, writes the enrichment artifact, and renders both markdown and HTML outputs. Remaining warnings are turnover / parity reconciliation warnings, not enrichment transport errors.
