### PR TITLE
Add Big Ten + Notre Dame readiness matrix scaffold

### DIFF
--- a/docs/bigten-nd-readiness-matrix.md
+++ b/docs/bigten-nd-readiness-matrix.md
@@ -1,0 +1,58 @@
+# Big Ten + Notre Dame Readiness Matrix
+
+Season: `2025`
+
+This matrix is the operator-facing readiness view for the currently supported production set:
+- Big Ten teams
+- Notre Dame
+
+Artifact coverage is auto-derived from the current production artifacts. Enrichment, warning triage, and confidence are intentionally left as `pending sweep` until the supported-set validation pass is completed.
+
+## Sources
+
+- Bundle: `https://github.com/victorres11/pbp-analysis/releases/tag/brief-artifacts-2025`
+- CFBStats snapshot: `https://github.com/victorres11/pbp-analysis/releases/tag/brief-artifacts-2025`
+- Verification report: `https://github.com/victorres11/pbp-analysis/releases/tag/brief-artifacts-2025`
+
+## Coverage Summary
+
+- Bundle coverage: `18/19` present
+- Snapshot coverage: `19/19` present
+- Verification coverage: `0/19` present
+
+## Current Flagged Gaps
+
+- Bundle artifact is missing supported teams: Northwestern.
+- Verification artifact is missing supported teams: Illinois, Indiana, Iowa, Maryland, Michigan, Michigan State, Minnesota, Nebraska, Northwestern, Notre Dame, Ohio State, Oregon, Penn State, Purdue, Rutgers, UCLA, USC, Washington, Wisconsin.
+- Verification artifact meta reports only 2 team entries for the current published set.
+- Bundle source was generated at 2026-03-17T17:38:57.629363+00:00.
+
+## Matrix
+
+| Team | Conf | Bundle | Snapshot | Verification | Enrichment | Warning triage | Confidence | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Illinois | Big Ten | present | present | missing | pending sweep | pending sweep | pending sweep | artifact gap |
+| Indiana | Big Ten | present | present | missing | pending sweep | pending sweep | pending sweep | artifact gap |
+| Iowa | Big Ten | present | present | missing | pending sweep | pending sweep | pending sweep | artifact gap |
+| Maryland | Big Ten | present | present | missing | pending sweep | pending sweep | pending sweep | artifact gap |
+| Michigan | Big Ten | present | present | missing | pending sweep | pending sweep | pending sweep | artifact gap |
+| Michigan State | Big Ten | present | present | missing | pending sweep | pending sweep | pending sweep | artifact gap |
+| Minnesota | Big Ten | present | present | missing | pending sweep | pending sweep | pending sweep | artifact gap |
+| Nebraska | Big Ten | present | present | missing | pending sweep | pending sweep | pending sweep | artifact gap |
+| Northwestern | Big Ten | missing | present | missing | pending sweep | pending sweep | pending sweep | artifact gap |
+| Notre Dame | Independent | present | present | missing | pending sweep | pending sweep | pending sweep | artifact gap |
+| Ohio State | Big Ten | present | present | missing | pending sweep | pending sweep | pending sweep | artifact gap |
+| Oregon | Big Ten | present | present | missing | pending sweep | pending sweep | pending sweep | artifact gap |
+| Penn State | Big Ten | present | present | missing | pending sweep | pending sweep | pending sweep | artifact gap |
+| Purdue | Big Ten | present | present | missing | pending sweep | pending sweep | pending sweep | artifact gap |
+| Rutgers | Big Ten | present | present | missing | pending sweep | pending sweep | pending sweep | artifact gap |
+| UCLA | Big Ten | present | present | missing | pending sweep | pending sweep | pending sweep | artifact gap |
+| USC | Big Ten | present | present | missing | pending sweep | pending sweep | pending sweep | artifact gap |
+| Washington | Big Ten | present | present | missing | pending sweep | pending sweep | pending sweep | artifact gap |
+| Wisconsin | Big Ten | present | present | missing | pending sweep | pending sweep | pending sweep | artifact gap |
+
+## Notes
+
+- `present` means the team resolves from the current artifact payload.
+- `missing` means the team could not be found in that artifact and should be treated as a production gap.
+- `pending sweep` means the validation and operator triage work has not been completed for that dimension yet.

--- a/scripts/game_prep_brief/supported_team_readiness.py
+++ b/scripts/game_prep_brief/supported_team_readiness.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+import argparse
+import json
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .published_artifacts import fetch_published_artifact_json, published_artifact_release_url
+
+
+SUPPORTED_TEAMS = (
+    {"slug": "illinois", "name": "Illinois", "conference": "Big Ten"},
+    {"slug": "indiana", "name": "Indiana", "conference": "Big Ten"},
+    {"slug": "iowa", "name": "Iowa", "conference": "Big Ten"},
+    {"slug": "maryland", "name": "Maryland", "conference": "Big Ten"},
+    {"slug": "michigan", "name": "Michigan", "conference": "Big Ten"},
+    {"slug": "michigan-state", "name": "Michigan State", "conference": "Big Ten"},
+    {"slug": "minnesota", "name": "Minnesota", "conference": "Big Ten"},
+    {"slug": "nebraska", "name": "Nebraska", "conference": "Big Ten"},
+    {"slug": "northwestern", "name": "Northwestern", "conference": "Big Ten"},
+    {"slug": "notre-dame", "name": "Notre Dame", "conference": "Independent"},
+    {"slug": "ohio-state", "name": "Ohio State", "conference": "Big Ten"},
+    {"slug": "oregon", "name": "Oregon", "conference": "Big Ten"},
+    {"slug": "penn-state", "name": "Penn State", "conference": "Big Ten"},
+    {"slug": "purdue", "name": "Purdue", "conference": "Big Ten"},
+    {"slug": "rutgers", "name": "Rutgers", "conference": "Big Ten"},
+    {"slug": "ucla", "name": "UCLA", "conference": "Big Ten"},
+    {"slug": "usc", "name": "USC", "conference": "Big Ten"},
+    {"slug": "washington", "name": "Washington", "conference": "Big Ten"},
+    {"slug": "wisconsin", "name": "Wisconsin", "conference": "Big Ten"},
+)
+
+PENDING_SWEEP = "pending sweep"
+
+
+@dataclass(frozen=True)
+class TeamReadinessRow:
+    conference: str
+    name: str
+    slug: str
+    bundle: str
+    snapshot: str
+    verification: str
+    enrichment: str
+    warnings: str
+    confidence: str
+    notes: str
+
+
+def _norm(value: str | None) -> str:
+    if not value:
+        return ""
+    cleaned = value.lower().replace("&", " and ")
+    return " ".join("".join(ch if ch.isalnum() else " " for ch in cleaned).split())
+
+
+def _slug_variants(team_slug: str, team_name: str) -> set[str]:
+    variants = {
+        team_slug.strip().lower(),
+        _norm(team_slug),
+        _norm(team_name),
+    }
+    name_slug = team_name.strip().lower().replace("&", " and ").replace(" ", "-")
+    variants.add(name_slug)
+    if team_slug == "notre-dame":
+        variants.update({"notredame", "notre dame", "nd"})
+    return {variant for variant in variants if variant}
+
+
+def _read_json_url(url: str) -> dict[str, Any]:
+    request = urllib.request.Request(
+        url,
+        headers={"User-Agent": "pbp-analysis-supported-team-readiness"},
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"Expected JSON object from {url}")
+    return payload
+
+
+def _load_artifact(source: str | None, *, logical_name: str, season: int) -> dict[str, Any]:
+    if not source:
+        return fetch_published_artifact_json(logical_name, season)
+    parsed = urllib.parse.urlparse(source)
+    if parsed.scheme in {"http", "https"}:
+        return _read_json_url(source)
+    path = Path(source).expanduser()
+    with open(path, encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"Expected JSON object from {path}")
+    return payload
+
+
+def _team_present(artifact: dict[str, Any], team_slug: str, team_name: str) -> bool:
+    teams = _artifact_team_map(artifact)
+    if not isinstance(teams, dict):
+        return False
+
+    variants = _slug_variants(team_slug, team_name)
+    for key, payload in teams.items():
+        if not isinstance(key, str):
+            continue
+        payload_candidates = {
+            _norm(key),
+            _norm(payload.get("team_slug")) if isinstance(payload, dict) else "",
+            _norm(payload.get("team_name")) if isinstance(payload, dict) else "",
+            _norm(payload.get("name")) if isinstance(payload, dict) else "",
+        }
+        payload_candidates.discard("")
+        if variants & payload_candidates:
+            return True
+    return False
+
+
+def _artifact_team_map(artifact: dict[str, Any]) -> dict[str, Any]:
+    teams = artifact.get("teams")
+    if not isinstance(teams, dict):
+        return {}
+    nested_teams = teams.get("teams")
+    nested_meta = teams.get("_meta")
+    if isinstance(nested_teams, dict) and isinstance(nested_meta, dict):
+        return nested_teams
+    return teams
+
+
+def build_readiness_rows(
+    *,
+    season: int,
+    bundle: dict[str, Any],
+    snapshot: dict[str, Any],
+    verification: dict[str, Any],
+) -> list[TeamReadinessRow]:
+    rows: list[TeamReadinessRow] = []
+    for team in SUPPORTED_TEAMS:
+        bundle_status = "present" if _team_present(bundle, team["slug"], team["name"]) else "missing"
+        snapshot_status = "present" if _team_present(snapshot, team["slug"], team["name"]) else "missing"
+        verification_status = "present" if _team_present(verification, team["slug"], team["name"]) else "missing"
+        notes_parts: list[str] = []
+        if "missing" in {bundle_status, snapshot_status, verification_status}:
+            notes_parts.append("artifact gap")
+        rows.append(
+            TeamReadinessRow(
+                conference=team["conference"],
+                name=team["name"],
+                slug=team["slug"],
+                bundle=bundle_status,
+                snapshot=snapshot_status,
+                verification=verification_status,
+                enrichment=PENDING_SWEEP,
+                warnings=PENDING_SWEEP,
+                confidence=PENDING_SWEEP,
+                notes=", ".join(notes_parts) if notes_parts else "",
+            )
+        )
+    return rows
+
+
+def render_markdown(
+    *,
+    season: int,
+    rows: list[TeamReadinessRow],
+    bundle_source: str | None,
+    snapshot_source: str | None,
+    verification_source: str | None,
+    findings: list[str] | None = None,
+) -> str:
+    bundle_present = sum(1 for row in rows if row.bundle == "present")
+    snapshot_present = sum(1 for row in rows if row.snapshot == "present")
+    verification_present = sum(1 for row in rows if row.verification == "present")
+    total = len(rows)
+
+    lines = [
+        "# Big Ten + Notre Dame Readiness Matrix",
+        "",
+        f"Season: `{season}`",
+        "",
+        "This matrix is the operator-facing readiness view for the currently supported production set:",
+        "- Big Ten teams",
+        "- Notre Dame",
+        "",
+        "Artifact coverage is auto-derived from the current production artifacts. Enrichment, warning triage, and confidence are intentionally left as `pending sweep` until the supported-set validation pass is completed.",
+        "",
+        "## Sources",
+        "",
+        f"- Bundle: `{bundle_source or published_artifact_release_url(season)}`",
+        f"- CFBStats snapshot: `{snapshot_source or published_artifact_release_url(season)}`",
+        f"- Verification report: `{verification_source or published_artifact_release_url(season)}`",
+        "",
+        "## Coverage Summary",
+        "",
+        f"- Bundle coverage: `{bundle_present}/{total}` present",
+        f"- Snapshot coverage: `{snapshot_present}/{total}` present",
+        f"- Verification coverage: `{verification_present}/{total}` present",
+    ]
+
+    if findings:
+        lines.extend(
+            [
+                "",
+                "## Current Flagged Gaps",
+                "",
+                *[f"- {finding}" for finding in findings],
+            ]
+        )
+
+    lines.extend(
+        [
+        "",
+        "## Matrix",
+        "",
+        "| Team | Conf | Bundle | Snapshot | Verification | Enrichment | Warning triage | Confidence | Notes |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+        ]
+    )
+
+    for row in rows:
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    row.name,
+                    row.conference,
+                    row.bundle,
+                    row.snapshot,
+                    row.verification,
+                    row.enrichment,
+                    row.warnings,
+                    row.confidence,
+                    row.notes or "",
+                ]
+            )
+            + " |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            "- `present` means the team resolves from the current artifact payload.",
+            "- `missing` means the team could not be found in that artifact and should be treated as a production gap.",
+            "- `pending sweep` means the validation and operator triage work has not been completed for that dimension yet.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def build_findings(
+    *,
+    rows: list[TeamReadinessRow],
+    bundle: dict[str, Any],
+    snapshot: dict[str, Any],
+    verification: dict[str, Any],
+) -> list[str]:
+    findings: list[str] = []
+    missing_bundle = [row.name for row in rows if row.bundle == "missing"]
+    missing_snapshot = [row.name for row in rows if row.snapshot == "missing"]
+    missing_verification = [row.name for row in rows if row.verification == "missing"]
+
+    if missing_bundle:
+        findings.append(f"Bundle artifact is missing supported teams: {', '.join(missing_bundle)}.")
+    if missing_snapshot:
+        findings.append(f"Snapshot artifact is missing supported teams: {', '.join(missing_snapshot)}.")
+    if missing_verification:
+        findings.append(
+            "Verification artifact is missing supported teams: "
+            + ", ".join(missing_verification)
+            + "."
+        )
+
+    verification_meta = verification.get("meta")
+    if isinstance(verification_meta, dict):
+        team_count = verification_meta.get("team_count")
+        if isinstance(team_count, int) and team_count < len(rows):
+            findings.append(
+                f"Verification artifact meta reports only {team_count} team entries for the current published set."
+            )
+
+    snapshot_meta = snapshot.get("meta")
+    if isinstance(snapshot_meta, dict):
+        team_count = snapshot_meta.get("team_count")
+        if isinstance(team_count, int) and team_count < len(rows):
+            findings.append(
+                f"Snapshot artifact meta reports only {team_count} team entries for the current published set."
+            )
+
+    bundle_meta = bundle.get("_meta")
+    if isinstance(bundle_meta, dict):
+        generated_at = bundle_meta.get("generated_at")
+        if generated_at:
+            findings.append(f"Bundle source was generated at {generated_at}.")
+
+    return findings
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate the Big Ten + Notre Dame readiness matrix.")
+    parser.add_argument("--season", type=int, default=2025)
+    parser.add_argument("--bundle")
+    parser.add_argument("--cfbstats-snapshot")
+    parser.add_argument("--cfbstats-verification-report")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("docs/bigten-nd-readiness-matrix.md"),
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    bundle = _load_artifact(args.bundle, logical_name="bundle", season=args.season)
+    snapshot = _load_artifact(args.cfbstats_snapshot, logical_name="cfbstats_snapshot", season=args.season)
+    verification = _load_artifact(
+        args.cfbstats_verification_report,
+        logical_name="cfbstats_verification_report",
+        season=args.season,
+    )
+
+    rows = build_readiness_rows(
+        season=args.season,
+        bundle=bundle,
+        snapshot=snapshot,
+        verification=verification,
+    )
+    markdown = render_markdown(
+        season=args.season,
+        rows=rows,
+        bundle_source=args.bundle,
+        snapshot_source=args.cfbstats_snapshot,
+        verification_source=args.cfbstats_verification_report,
+        findings=build_findings(
+            rows=rows,
+            bundle=bundle,
+            snapshot=snapshot,
+            verification=verification,
+        ),
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(markdown, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_supported_team_readiness.py
+++ b/tests/test_supported_team_readiness.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from scripts.game_prep_brief.supported_team_readiness import build_readiness_rows, render_markdown
+
+
+def test_build_readiness_rows_marks_artifact_presence_and_missing() -> None:
+    bundle = {"teams": {"washington": {"team_name": "Washington"}}}
+    snapshot = {"teams": {"washington": {"team_name": "Washington"}, "notre-dame": {"team_name": "Notre Dame"}}}
+    verification = {"teams": {"washington": {"team_name": "Washington"}}}
+
+    rows = build_readiness_rows(
+        season=2025,
+        bundle=bundle,
+        snapshot=snapshot,
+        verification=verification,
+    )
+    washington = next(row for row in rows if row.slug == "washington")
+    notre_dame = next(row for row in rows if row.slug == "notre-dame")
+
+    assert washington.bundle == "present"
+    assert washington.snapshot == "present"
+    assert washington.verification == "present"
+    assert washington.enrichment == "pending sweep"
+    assert washington.confidence == "pending sweep"
+
+    assert notre_dame.bundle == "missing"
+    assert notre_dame.snapshot == "present"
+    assert notre_dame.verification == "missing"
+    assert notre_dame.notes == "artifact gap"
+
+
+def test_render_markdown_summarizes_supported_set() -> None:
+    rows = build_readiness_rows(
+        season=2025,
+        bundle={"teams": {"washington": {"team_name": "Washington"}}},
+        snapshot={"teams": {"washington": {"team_name": "Washington"}}},
+        verification={"teams": {"washington": {"team_name": "Washington"}}},
+    )
+
+    markdown = render_markdown(
+        season=2025,
+        rows=rows,
+        bundle_source=None,
+        snapshot_source=None,
+        verification_source=None,
+        findings=["Bundle artifact is missing supported teams: Northwestern."],
+    )
+
+    assert "# Big Ten + Notre Dame Readiness Matrix" in markdown
+    assert "## Current Flagged Gaps" in markdown
+    assert "Bundle artifact is missing supported teams: Northwestern." in markdown
+    assert "Big Ten teams" in markdown
+    assert "Notre Dame" in markdown
+    assert "| Team | Conf | Bundle | Snapshot | Verification | Enrichment | Warning triage | Confidence | Notes |" in markdown
+    assert "| Washington | Big Ten | present | present | present | pending sweep | pending sweep | pending sweep |  |" in markdown


### PR DESCRIPTION
## Summary
- add a checked-in Big Ten + Notre Dame readiness matrix for the current supported production set
- add a small generator that reads the published bundle/snapshot/verification artifacts and renders the matrix markdown
- add focused tests around supported-team presence resolution and markdown output

## Why this is the right next step
We agreed to stop treating all FBS / Power 4 teams as equally production-ready right now. This PR makes the supported production scope explicit and gives us a shared artifact for the next phase:
- Big Ten teams
- Notre Dame

The matrix intentionally leaves enrichment, warning triage, and confidence as `pending sweep` for now. That is deliberate. The follow-up validation sweep should fill those columns in with real operator signal instead of guesses.

## Current signal from the generated matrix
The first generated 2025 matrix already surfaces two real production gaps:
- the published bundle is missing Northwestern
- the published verification artifact resolves `0/19` supported teams and its metadata reports only `2` team entries, which looks like a malformed published verification payload rather than a matrix bug

That is exactly the kind of visibility this phase is supposed to produce before we expand beyond the supported set.

## Validation
- `PYTHONPATH=. /Users/victorres/projects2/pbp/.venv/bin/python -m pytest -q tests/test_supported_team_readiness.py`
- `PYTHONPATH=. /Users/victorres/projects2/pbp/.venv/bin/python -m scripts.game_prep_brief.supported_team_readiness --season 2025`
