### PR TITLE
Triage supported-set brief warnings for operator readiness

### DIFF
--- a/docs/bigten-nd-readiness-matrix.md
+++ b/docs/bigten-nd-readiness-matrix.md
@@ -8,6 +8,8 @@ This matrix is the operator-facing readiness view for the currently supported pr
 
 Artifact coverage is auto-derived from the current production artifacts. Enrichment, warning triage, and confidence merge current artifact state with the latest supported-set validation sweep when one is available.
 
+Current operator warning policy is documented in [bigten-nd-warning-triage.md](./bigten-nd-warning-triage.md).
+
 ## Sources
 
 - Bundle: `https://github.com/victorres11/pbp-analysis/releases/tag/brief-artifacts-2025`
@@ -32,23 +34,23 @@ Artifact coverage is auto-derived from the current production artifacts. Enrichm
 
 | Team | Conf | Bundle | Snapshot | Verification | Enrichment | Warning triage | Confidence | Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Illinois | Big Ten | present | present | missing | not checked | data quality | attention | artifact gap, 8 data-quality warning(s) |
-| Indiana | Big Ten | present | present | missing | not checked | data quality | attention | artifact gap, 4 data-quality warning(s) |
-| Iowa | Big Ten | present | present | missing | not checked | data quality | attention | artifact gap, 4 data-quality warning(s) |
-| Maryland | Big Ten | present | present | missing | not checked | data quality | attention | artifact gap, 2 data-quality warning(s) |
-| Michigan | Big Ten | present | present | missing | not checked | data quality | attention | artifact gap, 6 data-quality warning(s) |
-| Michigan State | Big Ten | present | present | missing | not checked | data quality | attention | artifact gap, 2 data-quality warning(s) |
-| Minnesota | Big Ten | present | present | missing | not checked | data quality | attention | artifact gap, 2 data-quality warning(s) |
-| Nebraska | Big Ten | present | present | missing | not checked | data quality | attention | artifact gap, 4 data-quality warning(s) |
-| Northwestern | Big Ten | missing | present | missing | not checked | artifact gap | attention | artifact gap |
-| Notre Dame | Independent | present | present | missing | not checked | data quality | attention | artifact gap, 4 data-quality warning(s) |
+| Illinois | Big Ten | present | present | missing | not checked | known gap | attention | artifact gap, 8 data-quality warning(s) |
+| Indiana | Big Ten | present | present | missing | not checked | known gap | attention | artifact gap, 4 data-quality warning(s) |
+| Iowa | Big Ten | present | present | missing | not checked | known gap | attention | artifact gap, 4 data-quality warning(s) |
+| Maryland | Big Ten | present | present | missing | not checked | known gap | attention | artifact gap, 2 data-quality warning(s) |
+| Michigan | Big Ten | present | present | missing | not checked | known gap | attention | artifact gap, 6 data-quality warning(s) |
+| Michigan State | Big Ten | present | present | missing | not checked | known gap | attention | artifact gap, 2 data-quality warning(s) |
+| Minnesota | Big Ten | present | present | missing | not checked | known gap | attention | artifact gap, 2 data-quality warning(s) |
+| Nebraska | Big Ten | present | present | missing | not checked | known gap | attention | artifact gap, 4 data-quality warning(s) |
+| Northwestern | Big Ten | missing | present | missing | not checked | must-fix | attention | artifact gap |
+| Notre Dame | Independent | present | present | missing | not checked | known gap | attention | artifact gap, 4 data-quality warning(s) |
 | Ohio State | Big Ten | present | present | missing | not checked | clean | attention | artifact gap |
-| Oregon | Big Ten | present | present | missing | not checked | data quality | attention | artifact gap, 5 data-quality warning(s) |
-| Penn State | Big Ten | present | present | missing | not checked | data quality | attention | artifact gap, 5 data-quality warning(s) |
-| Purdue | Big Ten | present | present | missing | not checked | data quality | attention | artifact gap, 4 data-quality warning(s) |
-| Rutgers | Big Ten | present | present | missing | not checked | data quality | attention | artifact gap, 1 data-quality warning(s) |
-| UCLA | Big Ten | present | present | missing | not checked | data quality | attention | artifact gap, 4 data-quality warning(s) |
-| USC | Big Ten | present | present | missing | not checked | data quality | attention | artifact gap, 4 data-quality warning(s) |
+| Oregon | Big Ten | present | present | missing | not checked | known gap | attention | artifact gap, 5 data-quality warning(s) |
+| Penn State | Big Ten | present | present | missing | not checked | known gap | attention | artifact gap, 5 data-quality warning(s) |
+| Purdue | Big Ten | present | present | missing | not checked | known gap | attention | artifact gap, 4 data-quality warning(s) |
+| Rutgers | Big Ten | present | present | missing | not checked | known gap | attention | artifact gap, 1 data-quality warning(s) |
+| UCLA | Big Ten | present | present | missing | not checked | known gap | attention | artifact gap, 4 data-quality warning(s) |
+| USC | Big Ten | present | present | missing | not checked | known gap | attention | artifact gap, 4 data-quality warning(s) |
 | Washington | Big Ten | present | present | missing | not checked | clean | attention | artifact gap |
 | Wisconsin | Big Ten | present | present | missing | not checked | clean | attention | artifact gap |
 

--- a/docs/bigten-nd-warning-triage.md
+++ b/docs/bigten-nd-warning-triage.md
@@ -1,0 +1,79 @@
+# Big Ten + Notre Dame Warning Triage
+
+Season: `2025`
+
+This document translates the supported-set sweep output into operator-facing severity classes for the current production scope:
+
+- Big Ten teams
+- Notre Dame
+
+Source inputs:
+
+- validation sweep: [bigten-nd-validation-sweep.md](./bigten-nd-validation-sweep.md)
+- readiness matrix: [bigten-nd-readiness-matrix.md](./bigten-nd-readiness-matrix.md)
+
+## Triage Summary
+
+- `must-fix`: blocks client-facing confidence for the affected team or release
+- `known gap`: acceptable to keep visible to operators; does not block supported-set brief delivery on its own
+- `noise`: should be suppressed or reworded because it does not represent an operator action item
+
+## Must-Fix
+
+### Northwestern missing team payload in published bundle
+
+- Current warning: `Northwestern: missing team payload in XML bundle`
+- Why it matters: the brief renders with a placeholder Northwestern side instead of a complete supported-team payload
+- Follow-up: [#229](https://github.com/victorres11/pbp-analysis/issues/229)
+
+### Published verification artifact missing supported-set coverage
+
+- Current readiness finding: published verification coverage is `0/19` and artifact metadata reports only `2` team entries
+- Why it matters: this is a release-contract gap across the supported production set, even when direct brief rendering succeeds
+- Follow-up: [#230](https://github.com/victorres11/pbp-analysis/issues/230)
+
+## Acceptable Known Gaps
+
+These should remain visible to operators for now, but they are not treated as release blockers by themselves.
+
+### Turnover reconciliation mismatch
+
+- Example: `Turnover reconciliation mismatch for Illinois ...`
+- Meaning: season-level bundle-derived turnover totals do not exactly match XML/source reconciliation rows
+- Operator action: note it, but do not block a supported-set brief solely on this warning
+
+### Turnover game mismatches
+
+- Example: `Turnover game mismatches for Indiana ...`
+- Meaning: one or more game-level turnover/POT details differ from XML/source rows
+- Operator action: treat as a known data-quality warning unless it is tied to a must-fix artifact gap
+
+### Fourth-down parity delta
+
+- Example: `Illinois: 4th-down parity delta +5.4 pts ...`
+- Meaning: parser-derived fourth-down rate differs modestly from CFBStats/source parity
+- Operator action: keep visible, but do not block client-facing use for the supported set on this warning alone
+
+### Derived two-point totals differ from XML
+
+- Example: `Oregon: derived two-point totals differ from XML ...`
+- Meaning: parser-derived two-point totals do not fully match the XML source totals
+- Operator action: keep visible to operators as a known gap
+
+## Noise To Suppress Or Reword
+
+### Duplicate XML parity summary lines in sweep inventory
+
+- The sweep inventory can show both direct warning lines and split `XML parity` summary lines for the same underlying warning family
+- Operator action: no extra action required; this is duplicate presentation, not new severity
+
+### Enrichment-partial banner when the sweep intentionally skips enrichment
+
+- In `--no-enrichment` mode, the rendered brief can include enrichment-partial messaging even though the sweep is intentionally validating the core artifact-backed path only
+- Operator action: treat as expected for the no-enrichment sweep baseline, not as a supported-set blocker
+
+## Operator Guidance
+
+- `must-fix`: do not treat the affected team or published release as client-ready until the linked follow-up issue is resolved
+- `known gap`: acceptable to proceed for Big Ten + Notre Dame client delivery while leaving the warning visible to operators
+- `noise`: should not affect readiness decisions; clean it up in reporting when convenient

--- a/docs/demo-runbook.md
+++ b/docs/demo-runbook.md
@@ -173,6 +173,7 @@ To pause scheduled operations when needed:
 
 The published artifact contract is documented in [published-artifact-contract.md](./published-artifact-contract.md).
 The specific role of the `yr-data-api` bundle handoff path is documented in [yr-data-api-bundle-role.md](./yr-data-api-bundle-role.md).
+Supported-set readiness for Big Ten + Notre Dame is tracked in [bigten-nd-readiness-matrix.md](./bigten-nd-readiness-matrix.md) and the current operator warning policy is documented in [bigten-nd-warning-triage.md](./bigten-nd-warning-triage.md).
 
 Short version:
 
@@ -184,6 +185,19 @@ Short version:
 - `artifact_contract` inside the summary JSON is the machine-readable source of truth for whether a run is publishable
 - `yr-data-api/data/pbp_stats_bundle.json` remains a local handoff path, not a published artifact path
 - `enrichment_contract` inside the summary JSON is the machine-readable source of truth for enrichment policy and status
+
+### Supported-Set Warning Triage
+
+For the current supported production scope, operators should read warnings through the triage lens in [bigten-nd-warning-triage.md](./bigten-nd-warning-triage.md):
+
+- `must-fix`: blocks client-facing confidence until the linked follow-up issue is resolved
+- `known gap`: keep visible to operators, but do not block Big Ten + Notre Dame brief delivery on its own
+- `noise`: should be suppressed or reworded when convenient; not an operator decision point
+
+Current must-fix follow-ups:
+
+- [#229](https://github.com/victorres11/pbp-analysis/issues/229) restore Northwestern in the published bundle artifact
+- [#230](https://github.com/victorres11/pbp-analysis/issues/230) fix published verification artifact coverage for supported-set releases
 
 Direct brief runs follow the same contract by default:
 

--- a/scripts/game_prep_brief/supported_team_readiness.py
+++ b/scripts/game_prep_brief/supported_team_readiness.py
@@ -107,6 +107,14 @@ def _load_optional_json(path: Path | None) -> dict[str, Any] | None:
     return payload if isinstance(payload, dict) else None
 
 
+def triage_warning_status(status: str) -> str:
+    if status == "artifact gap":
+        return "must-fix"
+    if status == "data quality":
+        return "known gap"
+    return status
+
+
 def _team_present(artifact: dict[str, Any], team_slug: str, team_name: str) -> bool:
     teams = _artifact_team_map(artifact)
     if not isinstance(teams, dict):
@@ -157,7 +165,7 @@ def build_readiness_rows(
         if not isinstance(sweep_payload, dict):
             sweep_payload = {}
         enrichment_status = sweep_payload.get("enrichment_status", PENDING_SWEEP)
-        warning_status = sweep_payload.get("warning_status", PENDING_SWEEP)
+        warning_status = triage_warning_status(sweep_payload.get("warning_status", PENDING_SWEEP))
         confidence = sweep_payload.get("confidence", PENDING_SWEEP)
         notes_parts: list[str] = []
         if "missing" in {bundle_status, snapshot_status, verification_status}:
@@ -207,6 +215,8 @@ def render_markdown(
         "- Notre Dame",
         "",
         "Artifact coverage is auto-derived from the current production artifacts. Enrichment, warning triage, and confidence merge current artifact state with the latest supported-set validation sweep when one is available.",
+        "",
+        "Current operator warning policy is documented in [bigten-nd-warning-triage.md](./bigten-nd-warning-triage.md).",
         "",
         "## Sources",
         "",

--- a/tests/test_supported_team_readiness.py
+++ b/tests/test_supported_team_readiness.py
@@ -54,6 +54,28 @@ def test_build_readiness_rows_merges_sweep_statuses() -> None:
     assert washington.confidence == "ready"
 
 
+def test_build_readiness_rows_triages_warning_status_for_operator_readiness() -> None:
+    rows = build_readiness_rows(
+        season=2025,
+        bundle={"teams": {"washington": {"team_name": "Washington"}}},
+        snapshot={"teams": {"washington": {"team_name": "Washington"}}},
+        verification={"teams": {"washington": {"team_name": "Washington"}}},
+        sweep_report={
+            "teams": {
+                "washington": {
+                    "enrichment_status": "not checked",
+                    "warning_status": "data quality",
+                    "confidence": "caution",
+                    "notes": "4 data-quality warning(s)",
+                }
+            }
+        },
+    )
+    washington = next(row for row in rows if row.slug == "washington")
+
+    assert washington.warnings == "known gap"
+
+
 def test_render_markdown_summarizes_supported_set() -> None:
     rows = build_readiness_rows(
         season=2025,
@@ -76,6 +98,7 @@ def test_render_markdown_summarizes_supported_set() -> None:
     assert "Bundle artifact is missing supported teams: Northwestern." in markdown
     assert "Big Ten teams" in markdown
     assert "Notre Dame" in markdown
+    assert "[bigten-nd-warning-triage.md](./bigten-nd-warning-triage.md)" in markdown
     assert "| Team | Conf | Bundle | Snapshot | Verification | Enrichment | Warning triage | Confidence | Notes |" in markdown
     assert "| Washington | Big Ten | present | present | present | pending sweep | pending sweep | pending sweep |  |" in markdown
     assert "`not checked` means the current sweep intentionally skipped enrichment validation." in markdown


### PR DESCRIPTION
## Summary
- document Big Ten + Notre Dame warning severity in a dedicated triage guide
- open and link the current must-fix follow-up issues for Northwestern bundle coverage and published verification artifact coverage
- update the readiness matrix and runbook to use operator language (, , ) instead of raw warning categories

## Validation
- PYTHONPATH=. /Users/victorres/projects2/pbp/.venv/bin/python -m pytest -q tests/test_supported_team_readiness.py tests/test_supported_team_sweep.py tests/test_game_prep_loader_artifacts.py
- PYTHONPATH=. /Users/victorres/projects2/pbp/.venv/bin/python -m scripts.game_prep_brief.supported_team_readiness --season 2025

Closes #224