### PR TITLE
Fix turnover margin consistency in game briefs

### DIFF
--- a/scripts/game_prep_brief/loaders.py
+++ b/scripts/game_prep_brief/loaders.py
@@ -1875,10 +1875,23 @@ def _apply_turnover_xml_game_overrides(pbp_entry: dict | None) -> None:
         if isinstance(xml_stats.get("points_off_turnovers"), dict)
         else {}
     )
+    opponent_counts: dict[str, int] = {}
+    for game in games:
+        opp = str(game.get("opponent_abbr") or "").upper().strip()
+        if opp:
+            opponent_counts[opp] = opponent_counts.get(opp, 0) + 1
 
     def _set_if_numeric(game: dict, key: str, value: object) -> None:
         if isinstance(value, (int, float)):
             game[key] = int(value)
+
+    def _single_game_row(row: dict, opp: str) -> bool:
+        if not isinstance(row, dict):
+            return False
+        if opponent_counts.get(opp, 0) > 1:
+            return False
+        games_value = row.get("games")
+        return not isinstance(games_value, (int, float)) or int(games_value) <= 1
 
     for game in games:
         opp = str(game.get("opponent_abbr") or "").upper().strip()
@@ -1886,16 +1899,26 @@ def _apply_turnover_xml_game_overrides(pbp_entry: dict | None) -> None:
             continue
         tov_row = tov_cat.get(opp) if isinstance(tov_cat.get(opp), dict) else {}
         pot_row = pot_cat.get(opp) if isinstance(pot_cat.get(opp), dict) else {}
-        if tov_row:
+        if _single_game_row(tov_row, opp):
             _set_if_numeric(game, "turnovers_gained", tov_row.get("turnovers"))
             _set_if_numeric(game, "turnovers_lost", tov_row.get("turnovers_forced"))
             _set_if_numeric(game, "interceptions_gained", tov_row.get("interceptions"))
             _set_if_numeric(game, "interceptions_lost", tov_row.get("interceptions_forced"))
             _set_if_numeric(game, "fumbles_gained", tov_row.get("fumbles_lost"))
             _set_if_numeric(game, "fumbles_lost", tov_row.get("fumbles_recovered"))
-        if pot_row:
+        if _single_game_row(pot_row, opp):
             _set_if_numeric(game, "points_off_turnovers_for", pot_row.get("points_off_turnovers_allowed"))
             _set_if_numeric(game, "points_off_turnovers_against", pot_row.get("points_off_turnovers"))
+
+    if all(
+        isinstance(game.get("turnovers_gained"), int) and isinstance(game.get("turnovers_lost"), int)
+        for game in games
+    ):
+        aggregates = pbp_entry.get("aggregates") if isinstance(pbp_entry.get("aggregates"), dict) else {}
+        aggregates["turnover_margin"] = sum(int(game.get("turnovers_gained") or 0) for game in games) - sum(
+            int(game.get("turnovers_lost") or 0) for game in games
+        )
+        pbp_entry["aggregates"] = aggregates
 
 
 def _normalize_team_name_key(value: object) -> str:
@@ -3137,7 +3160,7 @@ def _turnover_reconciliation(pbp_entry: dict, game_recon: list[dict] | None = No
         "pot_for": _pick_int(xml_pot.get("points_off_turnovers"), None),
         "pot_against": _pick_int(xml_pot.get("points_off_turnovers_allowed"), None),
     }
-    if isinstance(game_recon, list) and game_recon:
+    if isinstance(game_recon, list) and game_recon and len(game_recon) == len(games):
         cfb_from_games = {
             "gained": 0,
             "lost": 0,
@@ -3191,6 +3214,11 @@ def _turnover_game_reconciliation(pbp_entry: dict) -> list[dict]:
         tov_cat = {}
     if not isinstance(pot_cat, dict):
         pot_cat = {}
+    opponent_counts: dict[str, int] = {}
+    for game in games:
+        opp = str(game.get("opponent_abbr") or "").upper().strip()
+        if opp:
+            opponent_counts[opp] = opponent_counts.get(opp, 0) + 1
 
     report: list[dict] = []
     for game in games:
@@ -3199,6 +3227,11 @@ def _turnover_game_reconciliation(pbp_entry: dict) -> list[dict]:
             continue
         tov_row = tov_cat.get(opp) if isinstance(tov_cat.get(opp), dict) else {}
         pot_row = pot_cat.get(opp) if isinstance(pot_cat.get(opp), dict) else {}
+        if opponent_counts.get(opp, 0) > 1:
+            if isinstance(tov_row, dict) and isinstance(tov_row.get("games"), (int, float)) and int(tov_row.get("games") or 0) > 1:
+                continue
+            if isinstance(pot_row, dict) and isinstance(pot_row.get("games"), (int, float)) and int(pot_row.get("games") or 0) > 1:
+                continue
         if not tov_row and not pot_row:
             continue
 

--- a/tests/test_turnover_game_row_overrides.py
+++ b/tests/test_turnover_game_row_overrides.py
@@ -3,6 +3,7 @@ from scripts.game_prep_brief import loaders
 
 def test_apply_turnover_xml_game_overrides_updates_game_totals_from_xml_rows() -> None:
     pbp_entry = {
+        "aggregates": {"turnover_margin": 99},
         "games": [
             {
                 "game_number": 1,
@@ -48,3 +49,73 @@ def test_apply_turnover_xml_game_overrides_updates_game_totals_from_xml_rows() -
     assert game["fumbles_lost"] == 1
     assert game["points_off_turnovers_for"] == 10
     assert game["points_off_turnovers_against"] == 0
+    assert pbp_entry["aggregates"]["turnover_margin"] == 2
+
+
+def test_apply_turnover_xml_game_overrides_skips_multi_game_opponent_rows() -> None:
+    pbp_entry = {
+        "aggregates": {"turnover_margin": 20},
+        "games": [
+            {
+                "game_number": 1,
+                "opponent_abbr": "ORE",
+                "turnovers_gained": 2,
+                "turnovers_lost": 1,
+                "points_off_turnovers_for": 7,
+                "points_off_turnovers_against": 0,
+            },
+            {
+                "game_number": 2,
+                "opponent_abbr": "ORE",
+                "turnovers_gained": 3,
+                "turnovers_lost": 0,
+                "points_off_turnovers_for": 14,
+                "points_off_turnovers_against": 0,
+            },
+            {
+                "game_number": 3,
+                "opponent_abbr": "KSU",
+                "turnovers_gained": 1,
+                "turnovers_lost": 0,
+                "points_off_turnovers_for": 0,
+                "points_off_turnovers_against": 0,
+            },
+        ],
+        "xml_stats": {
+            "turnovers": {
+                "ORE": {
+                    "games": 2,
+                    "turnovers": 5,
+                    "turnovers_forced": 1,
+                },
+                "KSU": {
+                    "games": 1,
+                    "turnovers": 2,
+                    "turnovers_forced": 0,
+                },
+            },
+            "points_off_turnovers": {
+                "ORE": {
+                    "games": 2,
+                    "points_off_turnovers": 0,
+                    "points_off_turnovers_allowed": 21,
+                },
+                "KSU": {
+                    "games": 1,
+                    "points_off_turnovers": 0,
+                    "points_off_turnovers_allowed": 7,
+                },
+            },
+        },
+    }
+
+    loaders._apply_turnover_xml_game_overrides(pbp_entry)
+
+    ore_game_1, ore_game_2, ksu_game = pbp_entry["games"]
+    assert (ore_game_1["turnovers_gained"], ore_game_1["turnovers_lost"]) == (2, 1)
+    assert (ore_game_2["turnovers_gained"], ore_game_2["turnovers_lost"]) == (3, 0)
+    assert ore_game_1["points_off_turnovers_for"] == 7
+    assert ore_game_2["points_off_turnovers_for"] == 14
+    assert (ksu_game["turnovers_gained"], ksu_game["turnovers_lost"]) == (2, 0)
+    assert ksu_game["points_off_turnovers_for"] == 7
+    assert pbp_entry["aggregates"]["turnover_margin"] == 6

--- a/tests/test_turnover_reconciliation.py
+++ b/tests/test_turnover_reconciliation.py
@@ -58,3 +58,76 @@ def test_turnover_reconciliation_uses_game_level_int_and_fumble_loss_splits() ->
     assert season_recon["delta"]["int_lost"] == 0
     assert season_recon["delta"]["fum_lost"] == 0
     assert season_recon["in_sync"] is True
+
+
+def test_turnover_reconciliation_keeps_season_rollup_when_duplicate_opponent_game_rows_are_ambiguous() -> None:
+    pbp_entry = {
+        "games": [
+            {
+                "game_number": 1,
+                "opponent_abbr": "ORE",
+                "turnovers_gained": 2,
+                "turnovers_lost": 1,
+                "interceptions_gained": 2,
+                "interceptions_lost": 1,
+                "fumbles_gained": 0,
+                "fumbles_lost": 0,
+                "points_off_turnovers_for": 3,
+                "points_off_turnovers_against": 7,
+            },
+            {
+                "game_number": 2,
+                "opponent_abbr": "ORE",
+                "turnovers_gained": 3,
+                "turnovers_lost": 0,
+                "interceptions_gained": 1,
+                "interceptions_lost": 0,
+                "fumbles_gained": 2,
+                "fumbles_lost": 0,
+                "points_off_turnovers_for": 21,
+                "points_off_turnovers_against": 0,
+            },
+        ],
+        "xml_stats": {
+            "turnovers": {
+                "ORE": {
+                    "games": 2,
+                    "turnovers": 5,
+                    "turnovers_forced": 1,
+                    "interceptions": 3,
+                    "interceptions_forced": 1,
+                    "fumbles_lost": 2,
+                    "fumbles_recovered": 0,
+                }
+            },
+            "points_off_turnovers": {
+                "ORE": {
+                    "games": 2,
+                    "points_off_turnovers": 0,
+                    "points_off_turnovers_allowed": 24,
+                }
+            },
+        },
+        "xml_rollups": {
+            "turnovers": {
+                "turnovers_forced": 5,
+                "turnovers": 1,
+                "interceptions": 1,
+                "fumbles_lost": 0,
+            },
+            "points_off_turnovers": {
+                "points_off_turnovers": 24,
+                "points_off_turnovers_allowed": 7,
+            },
+        },
+    }
+
+    game_recon = loaders._turnover_game_reconciliation(pbp_entry)
+    season_recon = loaders._turnover_reconciliation(pbp_entry, game_recon)
+
+    assert game_recon == []
+    assert season_recon["cfbstats"]["gained"] == 5
+    assert season_recon["cfbstats"]["lost"] == 1
+    assert season_recon["delta"]["gained"] == 0
+    assert season_recon["delta"]["lost"] == 0
+    assert season_recon["in_sync"] is True


### PR DESCRIPTION
## Summary
- keep turnover game overrides from applying combined multi-game opponent rows to each individual game
- recompute season turnover margin from the same game rows shown in the brief
- keep season reconciliation on XML rollups when game-level opponent rows are ambiguous

## Verification
- python3 -m pytest -q tests/test_turnover_game_row_overrides.py tests/test_turnover_reconciliation.py tests/test_game_prep_loader_artifacts.py