### PR TITLE
Prepare operator briefs for Utah matchups

### DIFF
--- a/config/team-readiness-2025.json
+++ b/config/team-readiness-2025.json
@@ -1,0 +1,150 @@
+{
+  "schema_version": 1,
+  "season": 2025,
+  "generated_by": "manual planning draft",
+  "notes": [
+    "Operator-facing readiness registry draft. Evidence should be updated as teams are onboarded.",
+    "Deliverable runs use selected-matchup artifacts; this registry tracks whether a team-season is safe to use."
+  ],
+  "statuses": {
+    "production_ready": "Team-season is approved for client deliverables.",
+    "existing_supported": "Team is in the current supported scope, but this registry entry still needs full production-ready evidence.",
+    "onboarding": "Team is being added or validated.",
+    "blocked": "Team cannot be used for a client deliverable without additional work.",
+    "unknown": "Team has not been evaluated."
+  },
+  "teams": {
+    "michigan": {
+      "display_name": "Michigan",
+      "conference": "Big Ten",
+      "status": "existing_supported",
+      "deliverable_status": "ready_with_warnings",
+      "statbroadcast": {
+        "status": "ready",
+        "expected_games": 13,
+        "found_games": 13,
+        "source": "current local bundle"
+      },
+      "cfbstats": {
+        "status": "ready",
+        "conference_scope": "Big Ten",
+        "snapshot_present": true
+      },
+      "pff": {
+        "status": "ready",
+        "slug": "michigan-wolverines"
+      },
+      "verification": {
+        "status": "warning",
+        "failures": 0,
+        "warnings": null,
+        "notes": [
+          "Current local verification report includes warning-level metrics."
+        ]
+      },
+      "notes": [
+        "Current local bundle has 13 Michigan games."
+      ]
+    },
+    "notre-dame": {
+      "display_name": "Notre Dame",
+      "conference": "Independents",
+      "status": "existing_supported",
+      "deliverable_status": "ready_with_warnings",
+      "statbroadcast": {
+        "status": "ready",
+        "expected_games": 12,
+        "found_games": 12,
+        "source": "current local bundle"
+      },
+      "cfbstats": {
+        "status": "ready",
+        "conference_scope": "Independents",
+        "snapshot_present": true
+      },
+      "pff": {
+        "status": "ready",
+        "slug": "notre-dame-fighting-irish"
+      },
+      "verification": {
+        "status": "warning",
+        "failures": 0,
+        "warnings": null,
+        "notes": [
+          "Current local verification report includes warning-level metrics."
+        ]
+      },
+      "notes": [
+        "Current local bundle has 12 Notre Dame games."
+      ]
+    },
+    "utah": {
+      "display_name": "Utah",
+      "conference": "Big 12",
+      "status": "production_ready_2025",
+      "deliverable_status": "ready_with_warnings",
+      "statbroadcast": {
+        "status": "complete",
+        "expected_games": 13,
+        "found_games": 13,
+        "source": "StatBroadcast archive XML discovery/backfill"
+      },
+      "cfbstats": {
+        "status": "verified",
+        "conference_scope": "Big 12",
+        "snapshot_present": true
+      },
+      "pff": {
+        "status": "partial",
+        "slug": "utah"
+      },
+      "verification": {
+        "status": "passed_with_warnings",
+        "failures": 0,
+        "warnings": 9,
+        "notes": [
+          "Full 19-team verifier report has zero fail metrics.",
+          "Utah warnings are bounded source/parity special cases."
+        ]
+      },
+      "notes": [
+        "CFBStats mapping resolved Utah to Big 12 during planning.",
+        "Generated 13 Utah normalized game briefs from StatBroadcast archive XML.",
+        "Operator smoke run for Michigan vs Utah exited 0 with selected-team verification pass=27 warning=13 fail=0.",
+        "Enrichment validated, but PFF FMT and Utah negative-play last-3 fields are partial."
+      ]
+    },
+    "uconn": {
+      "display_name": "UConn",
+      "canonical_name": "Connecticut",
+      "conference": "Independents",
+      "status": "unknown",
+      "deliverable_status": "blocked",
+      "statbroadcast": {
+        "status": "missing",
+        "expected_games": null,
+        "found_games": 0,
+        "source": "needs CollegePressBox/StatBroadcast backfill"
+      },
+      "cfbstats": {
+        "status": "needs_verification",
+        "conference_scope": "Independents",
+        "snapshot_present": false
+      },
+      "pff": {
+        "status": "unknown",
+        "slug": null
+      },
+      "verification": {
+        "status": "not_run",
+        "failures": null,
+        "warnings": null,
+        "notes": []
+      },
+      "notes": [
+        "Use this as the second non-current-scope proof after Michigan vs Utah.",
+        "Confirm UConn vs Connecticut naming before marking ready."
+      ]
+    }
+  }
+}

--- a/docs/checklists/michigan-vs-utah-2025.md
+++ b/docs/checklists/michigan-vs-utah-2025.md
@@ -1,0 +1,103 @@
+# Michigan vs Utah 2025 Delivery Checklist
+
+## Request
+
+- Matchup: Michigan vs Utah
+- Season: 2025
+- Status: smoke brief passed with warnings
+- Deliverable target: client-ready markdown and HTML brief
+
+## Expected Inputs
+
+- Michigan expected games: 13
+- Utah expected games: 13
+- PFF enrichment required: yes
+- CFBStats required: yes
+- Selected-matchup artifacts: yes
+
+## Preflight
+
+- [x] Michigan exists in selected bundle.
+- [x] Utah exists in selected bundle.
+- [x] Michigan found games equals expected games.
+- [x] Utah found games equals expected games.
+- [x] Michigan CFBStats rankings attach under Big Ten.
+- [x] Utah CFBStats rankings attach under Big 12.
+- [x] Michigan verification report is present.
+- [x] Utah verification report is present.
+- [x] Michigan PFF/enrichment is present.
+- [x] Utah PFF/enrichment is present.
+
+## Utah Backfill
+
+- [x] Confirm Utah StatBroadcast group id.
+- [x] Document Utah CollegePressBox URL and fallback source.
+- [x] Build Utah 2025 schedule from StatBroadcast archive XML.
+- [x] Review discovered event IDs and expected game count.
+- [x] Fetch all Utah archive XML payloads.
+- [x] Normalize Utah game briefs.
+- [x] Promote Utah normalized files into canonical game brief directory.
+- [x] Record Utah source abbreviations and aliases.
+- [x] Generate Utah bundle row.
+- [x] Run parity gate for Utah.
+
+## Matchup Artifact Generation
+
+- [x] Generate selected Michigan+Utah bundle.
+- [x] Generate selected Michigan+Utah CFBStats snapshot.
+- [x] Generate selected Michigan+Utah verification report.
+- [x] Generate selected Michigan+Utah enrichment.
+- [x] Render markdown.
+- [x] Render HTML.
+
+## Quality Gate
+
+- [x] No critical section is blank for Michigan.
+- [x] No critical section is blank for Utah.
+- [x] No unexplained verification fail metrics.
+- [x] Warnings are reviewed and either fixed or documented.
+- [x] Schedule rows look sane for both teams.
+- [x] Recent results look sane for both teams.
+- [x] Ranking highlights use conference-relative context.
+- [x] Penalty, turnover, situational, and special teams sections have real values.
+- [x] Final files are ready for delivery.
+
+## Issue Log
+
+Use this section for reroutes during backfill or validation.
+
+```text
+Issue:
+Impact:
+Evidence:
+Options:
+Chosen path:
+Follow-up:
+```
+
+```text
+Issue: Live StatBroadcast webservice metadata returned Cloudflare 403, and CollegePressBox automation did not have a logged-in cookie.
+Impact: The original handoff discovery path could not find Utah event IDs.
+Evidence: Direct archive pages exposed Final Stats XML; archive XML header scan found 13 Utah football games.
+Options: Require manual CollegePressBox HTML, broaden live ID scan, or use archive XML.
+Chosen path: Added archive XML discovery/backfill and generated Utah schedule/game briefs from archive XML.
+Follow-up: Keep CollegePressBox saved-HTML instructions as a troubleshooting path for future in-season cases.
+```
+
+```text
+Issue: Utah appears as UTAH, UTA, and UTES across StatBroadcast XML.
+Impact: Bundle initially split Utah into multiple pseudo-team abbreviations.
+Evidence: Utah probe bundle showed UTAH/UTA/Utes before adapter canonicalization.
+Options: Rewrite source files or canonicalize at adapter boundary.
+Chosen path: Canonicalized Utah name/abbreviation variants to UTAH in the StatBroadcast adapter.
+Follow-up: Add future team aliases as new non-Big-Ten teams are onboarded.
+```
+
+```text
+Issue: Enrichment is partial.
+Impact: Brief renders a warning for PFF FMT and Utah negative-play last-3 fields.
+Evidence: Enrichment artifact status is ok for both teams, but provider status includes partial PFF/negative-play reasons.
+Options: Block delivery, manually source missing fields, or deliver with documented warning.
+Chosen path: Deliver with warning because core PFF tempo/plays/tackles/TFL/sack fields are populated and pipeline validation passes.
+Follow-up: Investigate yr-data-api PFF FMT and Utah last-3 negative-play endpoints before broad non-Big-Ten rollout.
+```

--- a/docs/d1-matchup-expansion-plan.md
+++ b/docs/d1-matchup-expansion-plan.md
@@ -1,0 +1,204 @@
+# D1 Matchup Expansion Plan
+
+## Goal
+
+Generate broadcaster-grade game prep briefs for requested D1 matchups with the
+same quality bar as the current Big Ten plus Notre Dame workflow.
+
+The immediate deliverable is Michigan vs Utah for the 2025 season. The broader
+system should support 2026 in-season requests where the requested teams may come
+from any D1 conference and current-season source data only becomes available
+after games are played.
+
+## Operating Model
+
+Use selected-matchup artifacts for client deliverables and maintain a separate
+team readiness registry for confidence.
+
+Selected-matchup artifacts means a client request for Michigan vs Utah generates
+and validates artifacts for Michigan and Utah only:
+
+- PBP stats bundle
+- CFBStats snapshot
+- CFBStats verification report
+- PFF/enrichment payload
+- final markdown/html brief
+
+This prevents unrelated team issues from blocking a client deliverable. The
+readiness registry tracks which teams are already safe to run and which teams
+need onboarding or weekly data refresh.
+
+## Readiness Layers
+
+Readiness has two independent layers.
+
+Team integration readiness answers whether the system can handle the team at
+all:
+
+- canonical slug and display name
+- season-specific conference
+- StatBroadcast/CollegePressBox discovery information
+- known source abbreviations and aliases
+- CFBStats team and conference mapping
+- PFF mapping
+- parser/normalizer compatibility
+
+Weekly data readiness answers whether the team is current for the requested
+brief:
+
+- expected completed games for the run
+- StatBroadcast games found
+- CFBStats snapshot freshness
+- PFF/enrichment freshness
+- verification status for the selected teams
+
+For 2026, do not infer expected games from the week number. BYE weeks, Week 0,
+postponements, neutral sites, and bowls make that unsafe. Manual expected game
+counts are allowed and take priority over any schedule-derived default.
+
+## Decision Log
+
+### Decision 001: Client Deliverables Use Selected-Matchup Artifacts
+
+Production brief runs should generate and validate only the teams requested for
+that client matchup. This keeps turnaround predictable and avoids unrelated
+teams blocking delivery.
+
+### Decision 002: Readiness Is Team-Season Specific
+
+A team can be production-ready for 2025 while still only integration-ready for
+2026 before new-season games exist. Readiness records must include the season.
+
+### Decision 003: Weekly Freshness Uses Expected Game Counts
+
+The production gate compares found games to expected completed games. The
+operator may provide manual expected counts, especially around BYE weeks.
+
+### Decision 004: New Teams Must Be Onboarded Before Routine Runs
+
+If a client requests a team that is not production-ready, the system should
+enter onboarding/troubleshooting mode rather than silently generating a brief
+with empty sections.
+
+### Decision 005: CFBStats Scope Is Per Team
+
+Each team receives rankings from its own conference scope. A cross-conference
+matchup must not force both teams into one conference. Utah should use Big 12;
+Michigan should use Big Ten.
+
+## Production Deliverable Gate
+
+A client-ready matchup brief must satisfy these checks:
+
+- both teams exist in the selected bundle
+- both teams have nonzero source games
+- found games match expected completed games unless an override is recorded
+- both teams have CFBStats rankings
+- CFBStats rankings use each team's own conference scope
+- both teams have PFF/enrichment when PFF is required
+- verification report includes both selected teams
+- no unexplained verification fail metrics
+- core sections are not blank or `N/A`-only
+- markdown/html render successfully
+- warnings are visible in the output and summary
+
+Core sections are:
+
+- overview
+- schedule
+- rankings
+- matchup rows
+- explosives
+- scoring zones
+- turnovers
+- middle 8
+- situational downs
+- special teams
+- penalties
+
+## Immediate Milestone: Michigan vs Utah 2025
+
+1. Done: backfilled Utah 2025 StatBroadcast game briefs from archive XML.
+2. Done: confirmed Utah expected game count for the deliverable scope is 13.
+3. Done: added Utah aliases/metadata needed for bundle aggregation.
+4. Done: generated a bundle containing Michigan and Utah.
+5. Done: generated a CFBStats snapshot including Utah.
+6. Done: generated a verification report including Utah.
+7. Done: refreshed selected-team PFF/enrichment, with partial-provider warnings documented.
+8. Done: rendered markdown and HTML.
+9. Done: reviewed warnings and final content quality.
+10. Done: marked Utah 2025 ready with documented warnings.
+
+Definition of done:
+
+- Michigan vs Utah brief has meaningful data for both teams.
+- Utah CFBStats rankings show Big 12 context.
+- no critical section is blank for Utah.
+- verification failures are either fixed or explicitly documented.
+- delivery checklist is completed.
+
+## Second Proof: Notre Dame vs UConn 2025
+
+Use Notre Dame vs UConn as the second expansion proof because it exercises a
+different risk profile:
+
+- UConn/Connecticut canonical naming
+- independent conference scope behavior
+- PFF mapping outside current Big Ten-heavy path
+- non-Big-Ten deliverable after Utah
+
+## 2026 In-Season Model
+
+Before the 2026 season starts, teams can be integration-ready but not weekly
+data-ready. Once the season starts, a matchup run must include expected
+completed game counts.
+
+Example Week 5 run:
+
+```text
+Michigan expected completed games: 3
+Utah expected completed games: 4
+```
+
+The system should block if a selected team has fewer or more games than
+expected, unless the operator explicitly records why partial/stale/extra data is
+acceptable.
+
+Early-season modes:
+
+- preseason: previous-season data only
+- early season: current season to date plus prior-season context
+- in season: current season to date
+
+The current milestone uses 2025 data only. 2026 support should be added as a
+separate migration, not by overwriting 2025 assumptions.
+
+## Expansion Strategy
+
+Expand by demand and readiness, not by promising all D1 immediately.
+
+Recommended sequence:
+
+1. Michigan vs Utah deliverable.
+2. Notre Dame vs UConn deliverable.
+3. Weekly watchlist support for likely client-requested teams.
+4. Big 12 cohort, if Utah is the first successful non-Big-Ten proof.
+5. Broader FBS.
+6. FCS only after source coverage and validation behavior are understood.
+
+## Issue Log Template
+
+When a reroute is needed, record it in the delivery checklist or readiness
+notes:
+
+```text
+Issue:
+Impact:
+Evidence:
+Options:
+Chosen path:
+Follow-up:
+```
+
+This keeps troubleshooting visible and prevents one-off fixes from becoming
+undocumented assumptions.

--- a/operator/app.js
+++ b/operator/app.js
@@ -44,6 +44,10 @@ const SUPPORTED_TEAM_GROUPS = [
         label: "Independent",
         teams: ["Notre Dame"],
     },
+    {
+        label: "Big 12",
+        teams: ["Utah"],
+    },
 ];
 
 const WORKFLOW_PAGE = (repo) => `https://github.com/${repo}/actions/workflows/${DEFAULTS.workflowFile}`;
@@ -1222,7 +1226,7 @@ function renderOperatorNote(runsResult, publishedResult, repo, season) {
         noteParts.push("The published summary could not be loaded. A token may be required if the repo or release is private.");
     }
 
-    noteParts.push("Current production-ready support scope is Big Ten teams plus Notre Dame. Other teams may still run, but should be treated as exploratory until broader readiness work lands.");
+    noteParts.push("Current production-ready support scope is Big Ten teams, Notre Dame, and Utah. Other teams may still run, but should be treated as exploratory until broader readiness work lands.");
 
     return `
         <div class="metric-title">Operator note</div>

--- a/operator/index.html
+++ b/operator/index.html
@@ -24,7 +24,7 @@
                         warnings, alerts, and the latest evidence before delivery.
                     </p>
                     <p class="hero-scope">
-                        Supported scope: <strong>Big Ten teams + Notre Dame</strong>.
+                        Supported scope: <strong>Big Ten teams + Notre Dame + Utah</strong>.
                     </p>
                 </div>
             </div>

--- a/scripts/game_prep_brief/sections/situational.py
+++ b/scripts/game_prep_brief/sections/situational.py
@@ -55,6 +55,12 @@ def _pct_display(value: object) -> str:
 
 
 def _num_display(value: object, suffix: str = "") -> str:
+    if isinstance(value, str):
+        text = value.strip()
+        if suffix and text.endswith(suffix):
+            value = text[: -len(suffix)].strip()
+        elif not suffix and re.fullmatch(r"-?\d+(?:\.\d+)?%", text):
+            return text
     try:
         return f"{float(value):.1f}{suffix}"
     except (TypeError, ValueError):

--- a/scripts/game_prep_brief/sections/situational.py
+++ b/scripts/game_prep_brief/sections/situational.py
@@ -370,7 +370,7 @@ def _team_html(team: dict) -> str:
       <div class="block">
         <h4>Tempo</h4>
         <ul>
-          <li>Avg Time to Snap: {_display_or_unavailable(stats.get('pff_avg_play_clock'), 's')}{SRC_PFF}</li>
+          <li>Avg Play Clock Remaining: {_display_or_unavailable(stats.get('pff_avg_play_clock'), 's')}{SRC_PFF}</li>
           <li>Hurry-Up Rate (≤10s): {_display_or_unavailable(stats.get('pff_hurry_up_pct'))}{SRC_PFF}</li>
           <li>Plays/Game Offense (Season / L3): {_num_display(off_plays_pg)} / {_num_display(off_plays_l3)}{SRC_PBP}</li>
           <li>Plays/Game Defense Allowed (Season / L3): {_num_display(def_plays_pg)} / {_num_display(def_plays_l3)}{SRC_PBP}</li>
@@ -474,7 +474,7 @@ def _team_md(team: dict) -> str:
         f"- 3rd Down: {third_down} · {third_conv}/{third_att} ({f'{third_pct_derived}%' if isinstance(third_pct_derived, (int, float)) else 'N/A'}){third_down_l3_suffix}",
         f"- Blitz %: {_display_or_unavailable(blitz_pct, '%')} (L3: {_display_or_unavailable(blitz_pct_last3, '%')})",
         f"- Negative Plays O/D: {neg_off}/{neg_def} (L3: {neg_off_l3}/{neg_def_l3})",
-        f"- Avg Time to Snap: {_display_or_unavailable(stats.get('pff_avg_play_clock'), 's')} | Hurry-Up: {_display_or_unavailable(stats.get('pff_hurry_up_pct'))}",
+        f"- Avg Play Clock Remaining: {_display_or_unavailable(stats.get('pff_avg_play_clock'), 's')} | Hurry-Up: {_display_or_unavailable(stats.get('pff_hurry_up_pct'))}",
         f"- Plays/G O/D: {off_plays_pg}/{def_plays_pg} (L3: {off_plays_l3}/{def_plays_l3})",
         trenches_line,
         miss_fmt_line,

--- a/tests/test_enrichment_provider_contract.py
+++ b/tests/test_enrichment_provider_contract.py
@@ -46,7 +46,6 @@ def test_fetch_pff_snapshot_treats_zero_placeholder_as_partial_provider(monkeypa
         "pff/plays?side=def&format=text",
     ]
 
-
 def test_fetch_pff_snapshot_uses_json_payloads_and_games_played_fallback(monkeypatch) -> None:
     def _fake_fetch_text(_candidates: list[str], suffix: str, **_kwargs) -> dict[str, object]:
         payloads = {


### PR DESCRIPTION
## Summary
- add Utah to the operator/readiness surfaces for selected-matchup brief generation
- include the Michigan-Utah readiness checklist and D1 expansion plan docs
- render PFF hurry-up percent strings instead of `N/A`
- rename the tempo label to `Avg Play Clock Remaining`

## Validation
- `/opt/homebrew/bin/python3.13 -m pytest tests/test_enrichment_provider_contract.py -q`
- `/opt/homebrew/bin/python3.13 -m pytest -q --ignore=tests/test_game_prep_brief_golden.py`
- Michigan-Utah offline pipeline passed with selected-team verification fail=0, warning=13

## Notes
- This replaces the reused/conflicting `codex/bigten-nd-support-scope` PR branch with a clean branch based on current `main`
- Generated brief outputs remain local artifacts and are not committed in this PR
