### PR TITLE
Add UConn brief readiness support

### DIFF
--- a/config/team-readiness-2025.json
+++ b/config/team-readiness-2025.json
@@ -118,32 +118,43 @@
       "display_name": "UConn",
       "canonical_name": "Connecticut",
       "conference": "Independents",
-      "status": "unknown",
-      "deliverable_status": "blocked",
+      "status": "onboarding",
+      "deliverable_status": "core_ready_enrichment_blocked",
       "statbroadcast": {
-        "status": "missing",
-        "expected_games": null,
-        "found_games": 0,
-        "source": "needs CollegePressBox/StatBroadcast backfill"
+        "status": "complete",
+        "expected_games": 13,
+        "found_games": 13,
+        "source": "StatBroadcast archive XML plus SIDEARM Buffalo fallback"
       },
       "cfbstats": {
-        "status": "needs_verification",
+        "status": "verified",
         "conference_scope": "Independents",
-        "snapshot_present": false
+        "snapshot_present": true,
+        "canonical_key": "connecticut"
       },
       "pff": {
-        "status": "unknown",
-        "slug": null
+        "status": "blocked",
+        "slug": "connecticut-huskies",
+        "notes": [
+          "Local yr-data-api requires PFF_COOKIE before enrichment can be refreshed.",
+          "Deployed PFF endpoints timed out during UConn proof testing on 2026-04-14."
+        ]
       },
       "verification": {
-        "status": "not_run",
-        "failures": null,
-        "warnings": null,
-        "notes": []
+        "status": "passed_with_warnings",
+        "failures": 0,
+        "warnings": 12,
+        "notes": [
+          "Full 21-team verifier report has zero fail metrics.",
+          "UConn warnings are bounded source/parity special cases.",
+          "Preflight for Notre Dame vs UConn exits 0 when enrichment is not required."
+        ]
       },
       "notes": [
         "Use this as the second non-current-scope proof after Michigan vs Utah.",
-        "Confirm UConn vs Connecticut naming before marking ready."
+        "UConn bundle slug resolves to CFBStats Connecticut for independent conference rankings.",
+        "Core markdown/html smoke run exits 0 with populated penalties, rankings, and situational XML fields.",
+        "Do not mark fully production-ready until PFF enrichment can be refreshed or an explicit no-PFF delivery policy is approved."
       ]
     }
   }

--- a/docs/d1-matchup-expansion-plan.md
+++ b/docs/d1-matchup-expansion-plan.md
@@ -168,6 +168,38 @@ different risk profile:
 - PFF mapping outside current Big Ten-heavy path
 - non-Big-Ten deliverable after Utah
 
+Current status:
+
+1. Done: backfilled 13 UConn games for 2025.
+2. Done: used StatBroadcast archive XML for 12 games and SIDEARM boxscore data
+   for the Buffalo game that was missing from the archive links.
+3. Done: added UConn/Connecticut aliases in parser, API, and analysis lookup
+   paths.
+4. Done: generated a 21-team 2025 bundle including UConn, Utah, Notre Dame,
+   and the current supported Big Ten set.
+5. Done: generated a CFBStats snapshot where UConn resolves as Connecticut in
+   the Independents scope.
+6. Done: generated a verifier report with zero fail metrics; UConn carries 12
+   warning-level source/parity special cases.
+7. Done: preflighted Notre Dame vs UConn with expected games
+   `Notre Dame=12`, `UConn=13`, and expected conference `Independents` for both
+   teams. The run exits 0 when enrichment is not required.
+8. Done: rendered markdown and HTML with `--no-enrichment`; penalties,
+   rankings, schedule, explosives, zones, turnovers, middle 8, situational,
+   and special teams sections populate.
+9. Blocked: PFF enrichment has not been validated for this matchup. Local
+   `yr-data-api` needs `PFF_COOKIE`, and deployed PFF endpoints timed out during
+   proof testing on April 14, 2026.
+
+Definition of done before UConn is fully production-ready:
+
+- PFF enrichment refresh succeeds for Notre Dame and UConn, or an explicit
+  delivery policy allows a no-PFF brief with visible API-unavailable notices.
+- The final deliverable preflight passes with the policy selected for that
+  client request.
+- Any remaining warning-level verification findings are documented in the
+  readiness registry.
+
 ## 2026 In-Season Model
 
 Before the 2026 season starts, teams can be integration-ready but not weekly

--- a/scripts/game_prep_brief/loaders.py
+++ b/scripts/game_prep_brief/loaders.py
@@ -43,11 +43,20 @@ SLUG_ALIASES = {
     "utsa": "utsa",
     "byu": "byu",
     "arizona state": "asu",
+    "connecticut": "uconn",
+    "uconn": "uconn",
+    "u-conn": "uconn",
+}
+
+TEAM_NAME_ALIASES = {
+    "connecticut": {"connecticut", "uconn", "u conn", "u-conn"},
+    "uconn": {"connecticut", "uconn", "u conn", "u-conn"},
 }
 
 TEAM_API_ALIASES = {
     "ohio-state": ["ohio-state"],
     "washington": ["washington", "wash"],
+    "uconn": ["uconn", "connecticut", "connecticut-huskies"],
 }
 
 ENRICHMENT_KEYS = (
@@ -169,6 +178,8 @@ def _team_name_variants(team_name: str, team_slug: str) -> set[str]:
         variants.add(base.replace(" state", " st"))
     if " st" in base:
         variants.add(base.replace(" st", " state"))
+    for key in list(variants):
+        variants.update(_norm_team_name(alias) for alias in TEAM_NAME_ALIASES.get(key, set()))
     return {v for v in variants if v}
 
 def _is_url_source(value: str | Path | None) -> bool:

--- a/tests/test_game_prep_loader_artifacts.py
+++ b/tests/test_game_prep_loader_artifacts.py
@@ -284,6 +284,35 @@ def test_gather_team_data_uses_offline_cfbstats_artifacts(
     assert "Turnover-on-downs definition gap" in turnover_metric["note"]
 
 
+def test_artifact_team_entry_matches_uconn_connecticut_aliases() -> None:
+    snapshot = {
+        "teams": {
+            "connecticut": {
+                "team_name": "Connecticut",
+                "team_slug": "connecticut",
+                "rankings": {"all": {"scoring_offense": {"rank": 2}}},
+            }
+        }
+    }
+    bundle = {
+        "teams": {
+            "uconn": {
+                "team_name": "uconn",
+                "games_parsed": 13,
+            }
+        }
+    }
+
+    assert loaders.slugify("Connecticut") == "uconn"
+    assert loaders._artifact_team_entry(snapshot, "uconn", "UConn")["team_name"] == "Connecticut"
+    assert loaders._artifact_team_entry(bundle, "uconn", "Connecticut")["games_parsed"] == 13
+    assert loaders._candidate_team_ids("uconn", "UConn") == [
+        "uconn",
+        "connecticut",
+        "connecticut-huskies",
+    ]
+
+
 def test_turnovers_section_prefers_source_pot_totals_over_parser_game_sums() -> None:
     team = {
         "display_name": "Washington",


### PR DESCRIPTION
Summary
- Adds UConn/Connecticut aliases across analysis artifact lookup and API candidate IDs.
- Documents Notre Dame vs UConn proof status and records UConn as core-ready with PFF enrichment blocked.
- Keeps no-PFF deliverable policy explicit in the D1 expansion plan.

Verification
- /opt/homebrew/bin/python3.13 -m pytest tests/test_game_prep_loader_artifacts.py tests/test_matchup_preflight.py tests/test_supported_team_readiness.py tests/test_supported_team_sweep.py -q
- /opt/homebrew/bin/python3.13 -m scripts.game_prep_brief 'Notre Dame' UConn --season 2025 --xml-bundle ../yr-data-api/data/pbp_stats_bundle.json --cfbstats-snapshot ../pbp-parser/data/cfbstats_snapshots/cfbstats_2025.json --cfbstats-verification-report ../pbp-parser/data/cfbstats_reports/cfbstats_verification_2025.json --no-enrichment