### PR TITLE
Update UConn PFF readiness status

### DIFF
--- a/config/team-readiness-2025.json
+++ b/config/team-readiness-2025.json
@@ -118,8 +118,8 @@
       "display_name": "UConn",
       "canonical_name": "Connecticut",
       "conference": "Independents",
-      "status": "onboarding",
-      "deliverable_status": "core_ready_enrichment_blocked",
+      "status": "production_ready_2025",
+      "deliverable_status": "ready_with_warnings",
       "statbroadcast": {
         "status": "complete",
         "expected_games": 13,
@@ -133,11 +133,11 @@
         "canonical_key": "connecticut"
       },
       "pff": {
-        "status": "blocked",
+        "status": "partial",
         "slug": "connecticut-huskies",
         "notes": [
-          "Local yr-data-api requires PFF_COOKIE before enrichment can be refreshed.",
-          "Deployed PFF endpoints timed out during UConn proof testing on 2026-04-14."
+          "Fly PFF endpoints returned 200 for UConn/Connecticut play-clock and plays after the UConn alias deploy.",
+          "Notre Dame vs UConn enrichment artifact validates with UConn PFF provider partial because advanced missed-tackle/FMT charting is unavailable."
         ]
       },
       "verification": {
@@ -147,14 +147,14 @@
         "notes": [
           "Full 21-team verifier report has zero fail metrics.",
           "UConn warnings are bounded source/parity special cases.",
-          "Preflight for Notre Dame vs UConn exits 0 when enrichment is not required."
+          "Preflight for Notre Dame vs UConn exits 0 with enrichment required."
         ]
       },
       "notes": [
         "Use this as the second non-current-scope proof after Michigan vs Utah.",
         "UConn bundle slug resolves to CFBStats Connecticut for independent conference rankings.",
-        "Core markdown/html smoke run exits 0 with populated penalties, rankings, and situational XML fields.",
-        "Do not mark fully production-ready until PFF enrichment can be refreshed or an explicit no-PFF delivery policy is approved."
+        "Markdown/html smoke run exits 0 with populated penalties, rankings, situational XML fields, play-clock, and hurry-up.",
+        "Missed tackles/FMT remains XML-only/unavailable from advanced charting."
       ]
     }
   }

--- a/docs/d1-matchup-expansion-plan.md
+++ b/docs/d1-matchup-expansion-plan.md
@@ -183,22 +183,18 @@ Current status:
    warning-level source/parity special cases.
 7. Done: preflighted Notre Dame vs UConn with expected games
    `Notre Dame=12`, `UConn=13`, and expected conference `Independents` for both
-   teams. The run exits 0 when enrichment is not required.
-8. Done: rendered markdown and HTML with `--no-enrichment`; penalties,
-   rankings, schedule, explosives, zones, turnovers, middle 8, situational,
-   and special teams sections populate.
-9. Blocked: PFF enrichment has not been validated for this matchup. Local
-   `yr-data-api` needs `PFF_COOKIE`, and deployed PFF endpoints timed out during
-   proof testing on April 14, 2026.
+   teams. The run exits 0 with enrichment required.
+8. Done: refreshed the Notre Dame vs UConn enrichment artifact from the Fly API.
+   UConn play-clock, hurry-up, blitz, and PBP negative-play fields populate.
+9. Done: rendered markdown and HTML; penalties, rankings, schedule, explosives,
+   zones, turnovers, middle 8, situational, and special teams sections populate.
 
-Definition of done before UConn is fully production-ready:
+Remaining warning:
 
-- PFF enrichment refresh succeeds for Notre Dame and UConn, or an explicit
-  delivery policy allows a no-PFF brief with visible API-unavailable notices.
-- The final deliverable preflight passes with the policy selected for that
-  client request.
-- Any remaining warning-level verification findings are documented in the
-  readiness registry.
+- UConn advanced missed-tackle/FMT charting remains unavailable, so the brief
+  uses the XML-only coverage notice for that row. The selected-matchup preflight
+  still passes because the enrichment artifact is present and the PFF provider
+  is partial rather than missing.
 
 ## 2026 In-Season Model
 


### PR DESCRIPTION
Summary
- Updates the UConn readiness registry after Fly PFF endpoints were verified healthy.
- Records ND vs UConn as ready with warnings instead of PFF-blocked.
- Keeps the remaining UConn warning scoped to unavailable advanced missed-tackle/FMT charting.

Verification
- python3 -m json.tool config/team-readiness-2025.json
- /opt/homebrew/bin/python3.13 -m pytest tests/test_game_prep_loader_artifacts.py tests/test_matchup_preflight.py tests/test_supported_team_readiness.py tests/test_supported_team_sweep.py -q
- /opt/homebrew/bin/python3.13 -m scripts.game_prep_brief.matchup_preflight 'Notre Dame' UConn --season 2025 --bundle ../yr-data-api/data/pbp_stats_bundle.json --cfbstats-snapshot ../pbp-parser/data/cfbstats_snapshots/cfbstats_2025.json --cfbstats-verification-report ../pbp-parser/data/cfbstats_reports/cfbstats_verification_2025.json --enrichment-file outputs/game_prep_brief/notre-dame_vs_uconn_2025_enrichment.json --expected-games 'Notre Dame=12' --expected-games UConn=13 --expected-conference 'Notre Dame=Independents' --expected-conference UConn=Independents --require-expected-games