### PR TITLE
Gate selected matchups on team readiness

### DIFF
--- a/docs/d1-matchup-expansion-plan.md
+++ b/docs/d1-matchup-expansion-plan.md
@@ -126,6 +126,11 @@ verification findings remain visible without blocking.
 For the practical client-delivery flow, use the selected matchup operator
 runbook: `docs/selected-matchup-operator-runbook.md`.
 
+The selected-matchup operator command reads the readiness registry before
+rendering. Teams marked `blocked`, `unknown`, or `onboarding` block by default;
+teams marked `existing_supported` are allowed with warning-level visibility;
+teams marked `production_ready*` are approved by the registry gate.
+
 When a selected team is missing, stale, or source-blocked, use the team
 onboarding runbook: `docs/team-onboarding-troubleshooting-runbook.md`.
 

--- a/docs/selected-matchup-operator-runbook.md
+++ b/docs/selected-matchup-operator-runbook.md
@@ -8,6 +8,7 @@ unrelated team issues to block delivery.
 
 The current command assumes the selected teams already have season artifacts:
 
+- team readiness registry entry
 - PBP bundle
 - CFBStats snapshot
 - CFBStats verification report
@@ -54,6 +55,25 @@ Outputs are written to `outputs/game_prep_brief/`:
 - `<team1>_vs_<team2>_<season>_v2.md`
 - `<team1>_vs_<team2>_<season>_v2.html`
 
+By default, the command reads:
+
+```text
+config/team-readiness-<season>.json
+```
+
+Override it only when testing a draft registry:
+
+```bash
+python -m scripts.game_prep_brief.selected_matchup Michigan Utah \
+  --season 2025 \
+  --readiness-registry /path/to/team-readiness-2025.json \
+  --expected-games Michigan=13 \
+  --expected-games Utah=13
+```
+
+Use `--no-readiness-gate` only for local diagnosis. Client-delivery runs should
+keep the readiness gate enabled.
+
 ## Offline Or No-PFF Modes
 
 Reuse an existing enrichment artifact:
@@ -82,12 +102,21 @@ python -m scripts.game_prep_brief.selected_matchup Michigan Utah \
 Start with the operator summary JSON. It answers:
 
 - overall status
+- readiness registry pass/warning/fail counts
 - preflight pass/warning/fail counts
 - whether render passed
 - which artifact paths were used
 - whether enrichment was required
 
-Then open the preflight markdown. A client-ready run should have:
+Then open the readiness checks in the operator summary. A client-ready run
+should have:
+
+- registry entries for both selected teams
+- no readiness fail checks
+- `production_ready*` status, or `existing_supported` with understood warnings
+- no blocked deliverable status
+
+Then open the preflight markdown. A client-ready run should also have:
 
 - zero fail checks
 - expected games matching found games

--- a/scripts/game_prep_brief/selected_matchup.py
+++ b/scripts/game_prep_brief/selected_matchup.py
@@ -25,6 +25,7 @@ from .matchup_preflight import (
     _expected_games_for,
     _load_json,
     _parse_keyed_values,
+    _slug_variants,
     build_preflight_report,
     render_markdown as render_preflight_markdown,
 )
@@ -40,6 +41,7 @@ class OperatorPaths:
     bundle: Path
     cfbstats_snapshot: Path
     cfbstats_verification_report: Path
+    readiness_registry: Path
     enrichment_file: Path
     preflight_json: Path
     preflight_md: Path
@@ -60,6 +62,10 @@ def _default_verification_path(season: int) -> Path:
         / "cfbstats_reports"
         / f"cfbstats_verification_{season}.json"
     )
+
+
+def _default_readiness_registry_path(season: int) -> Path:
+    return ROOT / "config" / f"team-readiness-{season}.json"
 
 
 def _brief_base_name(team1_slug: str, team2_slug: str, season: int, week: int | None) -> str:
@@ -84,6 +90,7 @@ def resolve_paths(args: argparse.Namespace) -> OperatorPaths:
         cfbstats_verification_report=(
             args.cfbstats_verification_report or _default_verification_path(args.season)
         ).resolve(),
+        readiness_registry=(args.readiness_registry or _default_readiness_registry_path(args.season)).resolve(),
         enrichment_file=(args.enrichment_file or output_dir / f"{matchup_stem}_enrichment.json").resolve(),
         preflight_json=(args.preflight_json or output_dir / f"{matchup_stem}_preflight.json").resolve(),
         preflight_md=(args.preflight_md or output_dir / f"{matchup_stem}_preflight.md").resolve(),
@@ -101,6 +108,178 @@ def _write_json(path: Path, payload: dict[str, Any]) -> None:
 def _write_text(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
+
+
+def _readiness_candidates(key: str, payload: Any) -> set[str]:
+    candidates = {key, slugify(key)}
+    if isinstance(payload, dict):
+        for field in ("slug", "display_name", "canonical_name", "name"):
+            value = payload.get(field)
+            if isinstance(value, str):
+                candidates.update(_slug_variants(value))
+    return {candidate for candidate in candidates if candidate}
+
+
+def find_readiness_entry(
+    registry: dict[str, Any] | None,
+    team_name: str,
+) -> tuple[str, dict[str, Any]] | None:
+    teams = registry.get("teams") if isinstance(registry, dict) else None
+    if not isinstance(teams, dict):
+        return None
+    variants = _slug_variants(team_name)
+    for key, payload in teams.items():
+        if not isinstance(key, str) or not isinstance(payload, dict):
+            continue
+        if variants & _readiness_candidates(key, payload):
+            return key, payload
+    return None
+
+
+def _readiness_status_check(team: TeamRequest, entry_key: str, entry: dict[str, Any]) -> dict[str, Any]:
+    raw_status = str(entry.get("status") or "").strip()
+    status_key = raw_status.lower()
+    deliverable_status = str(entry.get("deliverable_status") or "").strip()
+    deliverable_key = deliverable_status.lower()
+
+    if status_key.startswith("production_ready"):
+        check_status = "pass"
+        message = f"Readiness status is {raw_status}."
+    elif status_key == "existing_supported":
+        check_status = "warning"
+        message = "Team is existing-supported, but registry evidence is not fully production-ready."
+    elif status_key in {"blocked", "unknown", "onboarding", ""}:
+        check_status = "fail"
+        message = f"Readiness status is {raw_status or 'missing'}."
+    else:
+        check_status = "warning"
+        message = f"Readiness status is unrecognized: {raw_status}."
+
+    if "blocked" in deliverable_key:
+        check_status = "fail"
+        message = f"Deliverable status is {deliverable_status}."
+
+    return {
+        "status": check_status,
+        "check": "readiness_status",
+        "team_slug": team.slug,
+        "message": message,
+        "details": {
+            "registry_key": entry_key,
+            "registry_status": raw_status,
+            "deliverable_status": deliverable_status,
+        },
+    }
+
+
+def _registry_expected_games_check(team: TeamRequest, entry: dict[str, Any]) -> dict[str, Any] | None:
+    if team.expected_games is None:
+        return None
+    statbroadcast = entry.get("statbroadcast")
+    if not isinstance(statbroadcast, dict):
+        return None
+    registry_expected = statbroadcast.get("expected_games")
+    if registry_expected is None:
+        return None
+    try:
+        registry_expected_int = int(registry_expected)
+    except (TypeError, ValueError):
+        return {
+            "status": "warning",
+            "check": "readiness_expected_games",
+            "team_slug": team.slug,
+            "message": f"Registry expected games is not numeric: {registry_expected}.",
+            "details": {"registry_expected_games": registry_expected, "operator_expected_games": team.expected_games},
+        }
+    status = "pass" if registry_expected_int == team.expected_games else "warning"
+    return {
+        "status": status,
+        "check": "readiness_expected_games",
+        "team_slug": team.slug,
+        "message": (
+            f"Registry expected games matches operator input ({team.expected_games})."
+            if status == "pass"
+            else f"Registry expected {registry_expected_int} game(s); operator expected {team.expected_games}."
+        ),
+        "details": {
+            "registry_expected_games": registry_expected_int,
+            "operator_expected_games": team.expected_games,
+        },
+    }
+
+
+def build_readiness_report(
+    *,
+    season: int,
+    teams: list[TeamRequest],
+    registry: dict[str, Any] | None,
+    registry_path: Path,
+    gate_enabled: bool,
+) -> dict[str, Any]:
+    checks: list[dict[str, Any]] = []
+    if registry is None:
+        checks.append(
+            {
+                "status": "fail" if gate_enabled else "warning",
+                "check": "readiness_registry",
+                "team_slug": None,
+                "message": f"Readiness registry is missing: {registry_path}",
+                "details": {"registry_path": str(registry_path)},
+            }
+        )
+    else:
+        for team in teams:
+            match = find_readiness_entry(registry, team.name)
+            if match is None:
+                checks.append(
+                    {
+                        "status": "fail" if gate_enabled else "warning",
+                        "check": "readiness_entry",
+                        "team_slug": team.slug,
+                        "message": "Team is missing from readiness registry.",
+                        "details": {"registry_path": str(registry_path)},
+                    }
+                )
+                continue
+            entry_key, entry = match
+            checks.append(
+                {
+                    "status": "pass",
+                    "check": "readiness_entry",
+                    "team_slug": team.slug,
+                    "message": f"Team has readiness registry entry {entry_key}.",
+                    "details": {
+                        "registry_key": entry_key,
+                        "display_name": entry.get("display_name"),
+                        "canonical_name": entry.get("canonical_name"),
+                    },
+                }
+            )
+            checks.append(_readiness_status_check(team, entry_key, entry))
+            expected_games_check = _registry_expected_games_check(team, entry)
+            if expected_games_check:
+                checks.append(expected_games_check)
+
+    status_counts = {
+        "pass": sum(1 for check in checks if check["status"] == "pass"),
+        "warning": sum(1 for check in checks if check["status"] == "warning"),
+        "fail": sum(1 for check in checks if check["status"] == "fail"),
+    }
+    return {
+        "meta": {
+            "artifact": "selected_matchup_readiness_report",
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "season": season,
+            "registry_path": str(registry_path),
+            "gate_enabled": gate_enabled,
+        },
+        "summary": {
+            "ready": status_counts["fail"] == 0,
+            "status": "ready" if status_counts["fail"] == 0 else "blocked",
+            "status_counts": status_counts,
+        },
+        "checks": checks,
+    }
 
 
 def refresh_enrichment(args: argparse.Namespace, paths: OperatorPaths) -> dict[str, Any] | None:
@@ -172,6 +351,7 @@ def _build_summary(
     *,
     args: argparse.Namespace,
     paths: OperatorPaths,
+    readiness: dict[str, Any],
     preflight: dict[str, Any],
     render_result: subprocess.CompletedProcess[str] | None,
     render_command: list[str] | None,
@@ -180,12 +360,16 @@ def _build_summary(
     if render_result is not None:
         render_status = "passed" if render_result.returncode == 0 else "failed"
 
-    ready = bool(preflight.get("summary", {}).get("ready")) and render_status in {"passed", "skipped"}
-    if args.skip_render and preflight.get("summary", {}).get("ready"):
+    readiness_ready = bool(readiness.get("summary", {}).get("ready")) or args.no_readiness_gate
+    preflight_ready = bool(preflight.get("summary", {}).get("ready"))
+    ready = readiness_ready and preflight_ready and render_status in {"passed", "skipped"}
+    if not readiness_ready:
+        status = "readiness_blocked"
+    elif args.skip_render and preflight_ready:
         status = "preflight_ready"
     elif ready:
         status = "ready"
-    elif not preflight.get("summary", {}).get("ready"):
+    elif not preflight_ready:
         status = "blocked"
     else:
         status = "render_failed"
@@ -203,6 +387,8 @@ def _build_summary(
             "team2_slug": slugify(args.team2),
         },
         "status": status,
+        "readiness": readiness.get("summary", {}),
+        "readiness_checks": readiness.get("checks", []),
         "preflight": preflight.get("summary", {}),
         "render": {
             "status": render_status,
@@ -213,12 +399,14 @@ def _build_summary(
         "policy": {
             "require_expected_games": args.require_expected_games,
             "require_enrichment": not args.no_enrichment,
+            "readiness_gate": not args.no_readiness_gate,
             "allow_blocked": args.allow_blocked,
         },
         "paths": {
             "bundle": str(paths.bundle),
             "cfbstats_snapshot": str(paths.cfbstats_snapshot),
             "cfbstats_verification_report": str(paths.cfbstats_verification_report),
+            "readiness_registry": None if args.no_readiness_gate else str(paths.readiness_registry),
             "enrichment_file": None if args.no_enrichment else str(paths.enrichment_file),
             "preflight_json": str(paths.preflight_json),
             "preflight_md": str(paths.preflight_md),
@@ -248,7 +436,22 @@ def run(args: argparse.Namespace) -> int:
         expected_conference=_expected_conference_for(args.team2, expected_conferences),
     )
 
-    enrichment = refresh_enrichment(args, paths)
+    readiness = build_readiness_report(
+        season=args.season,
+        teams=[team1, team2],
+        registry=None if args.no_readiness_gate else _load_json(paths.readiness_registry),
+        registry_path=paths.readiness_registry,
+        gate_enabled=not args.no_readiness_gate,
+    )
+    readiness_ready = bool(readiness["summary"]["ready"]) or args.no_readiness_gate
+    if not readiness_ready:
+        print("[block] Readiness gate failed; enrichment refresh disabled.", file=sys.stderr)
+
+    if readiness_ready or args.allow_blocked:
+        enrichment = refresh_enrichment(args, paths)
+    else:
+        enrichment = None if args.no_enrichment else _load_json(paths.enrichment_file)
+
     preflight = build_preflight_report(
         season=args.season,
         team1=team1,
@@ -276,19 +479,22 @@ def run(args: argparse.Namespace) -> int:
     preflight_ready = bool(preflight["summary"]["ready"])
     if args.skip_render:
         print("[skip] Brief render disabled by --skip-render", file=sys.stderr)
-    elif preflight_ready or args.allow_blocked:
+    elif (readiness_ready and preflight_ready) or args.allow_blocked:
         render_command = build_render_command(args, paths)
         render_result = run_render_command(render_command)
         if render_result.stdout:
             print(render_result.stdout, end="")
         if render_result.stderr:
             print(render_result.stderr, end="", file=sys.stderr)
+    elif not readiness_ready:
+        print("[block] Readiness gate failed; render skipped. Use --allow-blocked to force render.", file=sys.stderr)
     else:
         print("[block] Preflight failed; render skipped. Use --allow-blocked to force render.", file=sys.stderr)
 
     summary = _build_summary(
         args=args,
         paths=paths,
+        readiness=readiness,
         preflight=preflight,
         render_result=render_result,
         render_command=render_command,
@@ -296,6 +502,8 @@ def run(args: argparse.Namespace) -> int:
     _write_json(paths.summary_json, summary)
     print(f"[ok] Operator summary -> {paths.summary_json}", file=sys.stderr)
 
+    if not readiness_ready and not args.allow_blocked:
+        return 1
     if not preflight_ready and not args.allow_blocked:
         return 1
     if render_result is not None and render_result.returncode != 0:
@@ -317,6 +525,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--bundle", type=Path, default=DEFAULT_BUNDLE)
     parser.add_argument("--cfbstats-snapshot", type=Path, default=None)
     parser.add_argument("--cfbstats-verification-report", type=Path, default=None)
+    parser.add_argument("--readiness-registry", type=Path, default=None)
     parser.add_argument("--enrichment-file", type=Path, default=None)
     parser.add_argument("--preflight-json", type=Path, default=None)
     parser.add_argument("--preflight-md", type=Path, default=None)
@@ -348,6 +557,7 @@ def parse_args() -> argparse.Namespace:
         help="Refresh the matchup enrichment artifact from yr-data-api before preflight.",
     )
     parser.add_argument("--no-enrichment", action="store_true", help="Disable enrichment checks and rendering input.")
+    parser.add_argument("--no-readiness-gate", action="store_true", help="Do not block on team readiness registry status.")
     parser.add_argument("--skip-render", action="store_true", help="Run preflight and summary only.")
     parser.add_argument("--allow-blocked", action="store_true", help="Render even when preflight has fail checks.")
     parser.add_argument("--legacy-page-breaks", action="store_true")

--- a/tests/test_selected_matchup_operator.py
+++ b/tests/test_selected_matchup_operator.py
@@ -19,6 +19,7 @@ def _args(tmp_path: Path, **overrides) -> argparse.Namespace:
         "bundle": tmp_path / "bundle.json",
         "cfbstats_snapshot": None,
         "cfbstats_verification_report": None,
+        "readiness_registry": None,
         "enrichment_file": None,
         "preflight_json": None,
         "preflight_md": None,
@@ -28,6 +29,7 @@ def _args(tmp_path: Path, **overrides) -> argparse.Namespace:
         "require_expected_games": True,
         "refresh_enrichment": False,
         "no_enrichment": False,
+        "no_readiness_gate": False,
         "skip_render": False,
         "allow_blocked": False,
         "legacy_page_breaks": False,
@@ -41,6 +43,7 @@ def test_resolve_paths_uses_selected_matchup_names(tmp_path: Path) -> None:
     paths = selected_matchup.resolve_paths(_args(tmp_path))
 
     assert paths.enrichment_file == tmp_path / "notre-dame_vs_uconn_2025_enrichment.json"
+    assert paths.readiness_registry.name == "team-readiness-2025.json"
     assert paths.preflight_json == tmp_path / "notre-dame_vs_uconn_2025_preflight.json"
     assert paths.preflight_md == tmp_path / "notre-dame_vs_uconn_2025_preflight.md"
     assert paths.summary_json == tmp_path / "notre-dame_vs_uconn_2025_operator_summary.json"
@@ -75,11 +78,13 @@ def test_build_render_command_allows_no_enrichment(tmp_path: Path) -> None:
 def test_operator_summary_marks_blocked_preflight(tmp_path: Path) -> None:
     args = _args(tmp_path, skip_render=True)
     paths = selected_matchup.resolve_paths(args)
+    readiness = {"summary": {"ready": True, "status_counts": {"pass": 2, "warning": 0, "fail": 0}}, "checks": []}
     preflight = {"summary": {"ready": False, "status_counts": {"pass": 1, "warning": 0, "fail": 1}}}
 
     summary = selected_matchup._build_summary(
         args=args,
         paths=paths,
+        readiness=readiness,
         preflight=preflight,
         render_result=None,
         render_command=None,
@@ -93,12 +98,14 @@ def test_operator_summary_marks_blocked_preflight(tmp_path: Path) -> None:
 def test_operator_summary_marks_render_failure(tmp_path: Path) -> None:
     args = _args(tmp_path)
     paths = selected_matchup.resolve_paths(args)
+    readiness = {"summary": {"ready": True, "status_counts": {"pass": 2, "warning": 0, "fail": 0}}, "checks": []}
     preflight = {"summary": {"ready": True, "status_counts": {"pass": 10, "warning": 0, "fail": 0}}}
     render_result = subprocess.CompletedProcess(args=["brief"], returncode=2, stdout="", stderr="boom\n")
 
     summary = selected_matchup._build_summary(
         args=args,
         paths=paths,
+        readiness=readiness,
         preflight=preflight,
         render_result=render_result,
         render_command=["brief"],
@@ -107,3 +114,90 @@ def test_operator_summary_marks_render_failure(tmp_path: Path) -> None:
     assert summary["status"] == "render_failed"
     assert summary["render"]["exit_code"] == 2
     assert summary["render"]["stderr"] == ["boom"]
+
+
+def test_find_readiness_entry_matches_uconn_connecticut_alias() -> None:
+    registry = {"teams": {"uconn": {"display_name": "UConn", "canonical_name": "Connecticut"}}}
+
+    match = selected_matchup.find_readiness_entry(registry, "Connecticut")
+
+    assert match is not None
+    assert match[0] == "uconn"
+
+
+def test_build_readiness_report_allows_ready_with_supported_warning(tmp_path: Path) -> None:
+    registry = {
+        "teams": {
+            "notre-dame": {
+                "display_name": "Notre Dame",
+                "status": "existing_supported",
+                "deliverable_status": "ready_with_warnings",
+                "statbroadcast": {"expected_games": 12},
+            },
+            "uconn": {
+                "display_name": "UConn",
+                "canonical_name": "Connecticut",
+                "status": "production_ready_2025",
+                "deliverable_status": "ready_with_warnings",
+                "statbroadcast": {"expected_games": 13},
+            },
+        }
+    }
+
+    report = selected_matchup.build_readiness_report(
+        season=2025,
+        teams=[
+            selected_matchup.TeamRequest("Notre Dame", "notre-dame", expected_games=12),
+            selected_matchup.TeamRequest("UConn", "uconn", expected_games=13),
+        ],
+        registry=registry,
+        registry_path=tmp_path / "registry.json",
+        gate_enabled=True,
+    )
+
+    assert report["summary"]["ready"] is True
+    assert report["summary"]["status_counts"]["fail"] == 0
+    assert any(check["status"] == "warning" and check["team_slug"] == "notre-dame" for check in report["checks"])
+
+
+def test_build_readiness_report_blocks_onboarding_team(tmp_path: Path) -> None:
+    registry = {
+        "teams": {
+            "uconn": {
+                "display_name": "UConn",
+                "status": "onboarding",
+                "deliverable_status": "core_ready_enrichment_blocked",
+            }
+        }
+    }
+
+    report = selected_matchup.build_readiness_report(
+        season=2025,
+        teams=[selected_matchup.TeamRequest("UConn", "uconn", expected_games=13)],
+        registry=registry,
+        registry_path=tmp_path / "registry.json",
+        gate_enabled=True,
+    )
+
+    assert report["summary"]["ready"] is False
+    assert any(check["check"] == "readiness_status" and check["status"] == "fail" for check in report["checks"])
+
+
+def test_operator_summary_marks_readiness_blocked(tmp_path: Path) -> None:
+    args = _args(tmp_path, skip_render=True)
+    paths = selected_matchup.resolve_paths(args)
+    readiness = {"summary": {"ready": False, "status_counts": {"pass": 1, "warning": 0, "fail": 1}}, "checks": []}
+    preflight = {"summary": {"ready": True, "status_counts": {"pass": 10, "warning": 0, "fail": 0}}}
+
+    summary = selected_matchup._build_summary(
+        args=args,
+        paths=paths,
+        readiness=readiness,
+        preflight=preflight,
+        render_result=None,
+        render_command=None,
+    )
+
+    assert summary["status"] == "readiness_blocked"
+    assert summary["readiness"]["status_counts"]["fail"] == 1
+    assert summary["policy"]["readiness_gate"] is True


### PR DESCRIPTION
Summary
- Adds a readiness registry gate to the selected-matchup operator command.
- Records readiness summaries/checks in the operator summary and blocks teams marked blocked, unknown, or onboarding by default.
- Allows existing-supported teams with warning visibility and production-ready teams as pass.
- Documents the readiness gate in the selected matchup runbook and expansion plan.

Verification
- /opt/homebrew/bin/python3.13 -m pytest tests/test_selected_matchup_operator.py tests/test_matchup_preflight.py tests/test_game_prep_cli_enrichment.py tests/test_game_prep_loader_artifacts.py tests/test_supported_team_readiness.py tests/test_supported_team_sweep.py -q
- /opt/homebrew/bin/python3.13 -m scripts.game_prep_brief.selected_matchup 'Notre Dame' UConn --season 2025 --expected-games 'Notre Dame=12' --expected-games UConn=13 --expected-conference 'Notre Dame=Independents' --expected-conference UConn=Independents --enrichment-file outputs/game_prep_brief/notre-dame_vs_uconn_2025_enrichment.json
- git diff --check