### PR TITLE
Codify D1 matchup expansion plan

### DIFF
--- a/config/d1-matchup-expansion-2025.json
+++ b/config/d1-matchup-expansion-2025.json
@@ -1,0 +1,218 @@
+{
+  "schema_version": 1,
+  "season": 2025,
+  "goal": "Expand selected-matchup brief confidence from the current Big Ten-centered scope toward any D1 client request.",
+  "delivery_policy": {
+    "client_delivery_requires": [
+      "Both teams have production_ready* entries in the season readiness registry.",
+      "Expected completed games are confirmed by schedule check or operator input.",
+      "CFBStats conference scope is confirmed for each team.",
+      "StatBroadcast artifacts cover every expected completed game.",
+      "Verification has zero unexplained fail metrics.",
+      "PFF enrichment supplies average play clock, hurry-up rate, offensive plays per game, and defensive plays per game when enrichment is required.",
+      "Any partial enrichment or source fallback is visible in readiness notes and the brief."
+    ],
+    "do_not_assume": [
+      "Week number equals completed game count.",
+      "CollegePressBox links are always correct.",
+      "Independent teams have an obvious conference-comparison policy.",
+      "A PFF slug that works for one endpoint supplies all advanced charting fields."
+    ]
+  },
+  "waves": [
+    {
+      "id": "wave0-current-proofs",
+      "label": "Current completed proofs",
+      "objective": "Keep the already-approved cross-scope examples visible and machine-checkable.",
+      "matchups": [
+        {
+          "id": "michigan-utah",
+          "status": "complete",
+          "team1": "Michigan",
+          "team2": "Utah",
+          "coverage": [
+            "Big Ten",
+            "Big 12",
+            "cross-conference",
+            "non-Big-Ten team",
+            "PFF partial acceptable with notes"
+          ],
+          "expected_games": {
+            "Michigan": 13,
+            "Utah": 13
+          },
+          "expected_conference": {
+            "Michigan": "Big Ten",
+            "Utah": "Big 12"
+          },
+          "pff_enrichment": "required",
+          "evidence": [
+            "Operator-approved Michigan vs Utah deliverable passed quality review.",
+            "Readiness registry marks both teams production_ready_2025.",
+            "CFBStats maps Utah to Big 12 for conference-relative rankings."
+          ]
+        },
+        {
+          "id": "notre-dame-uconn",
+          "status": "complete",
+          "team1": "Notre Dame",
+          "team2": "UConn",
+          "coverage": [
+            "Independents",
+            "alias handling",
+            "PFF partial acceptable with notes",
+            "non-Big-Ten matchup"
+          ],
+          "expected_games": {
+            "Notre Dame": 12,
+            "UConn": 13
+          },
+          "expected_conference": {
+            "Notre Dame": "Independents",
+            "UConn": "Independents"
+          },
+          "pff_enrichment": "required",
+          "evidence": [
+            "Selected-matchup operator run exits 0 with enrichment required.",
+            "UConn resolves to CFBStats Connecticut.",
+            "Notre Dame PFF provider validates ok in the enrichment artifact."
+          ]
+        }
+      ]
+    },
+    {
+      "id": "wave1-next-onboarding",
+      "label": "Next representative onboarding targets",
+      "objective": "Prove the next conference/source shapes one at a time before claiming any-D1 confidence.",
+      "matchups": [
+        {
+          "id": "michigan-texas",
+          "status": "next",
+          "team1": "Michigan",
+          "team2": "Texas",
+          "coverage": [
+            "Big Ten",
+            "SEC",
+            "high-profile cross-conference",
+            "new PFF slug",
+            "full-season backfill from missing registry team"
+          ],
+          "expected_conference": {
+            "Michigan": "Big Ten",
+            "Texas": "SEC"
+          },
+          "pff_enrichment": "required",
+          "operator_questions": [
+            "Confirm Texas expected completed games for the selected 2025 cutoff.",
+            "Confirm whether Texas should be the first SEC readiness promotion."
+          ]
+        },
+        {
+          "id": "notre-dame-miami-fl",
+          "status": "next",
+          "team1": "Notre Dame",
+          "team2": "Miami (FL)",
+          "coverage": [
+            "Independents",
+            "ACC",
+            "ambiguous team name",
+            "independent comparison policy"
+          ],
+          "expected_conference": {
+            "Notre Dame": "Independents",
+            "Miami (FL)": "ACC"
+          },
+          "pff_enrichment": "required",
+          "tracking_issue": "https://github.com/victorres11/pbp-analysis/issues/250",
+          "operator_questions": [
+            "Confirm whether the brief should use Independents ranking context for Notre Dame or a matchup-relative comparison.",
+            "Confirm the Miami (FL) display name expected by the client."
+          ]
+        },
+        {
+          "id": "utah-byu",
+          "status": "planned",
+          "team1": "Utah",
+          "team2": "BYU",
+          "coverage": [
+            "Big 12",
+            "no Big Ten team",
+            "rivalry naming",
+            "conference-only matchup"
+          ],
+          "expected_conference": {
+            "Utah": "Big 12",
+            "BYU": "Big 12"
+          },
+          "pff_enrichment": "required",
+          "operator_questions": [
+            "Confirm BYU expected completed games for the selected 2025 cutoff.",
+            "Use this after Texas or Miami proves the new-team onboarding loop still holds."
+          ]
+        },
+        {
+          "id": "michigan-boise-state",
+          "status": "planned",
+          "team1": "Michigan",
+          "team2": "Boise State",
+          "coverage": [
+            "Big Ten",
+            "Mountain West",
+            "Group of Five",
+            "new PFF slug"
+          ],
+          "expected_conference": {
+            "Michigan": "Big Ten",
+            "Boise State": "Mountain West"
+          },
+          "pff_enrichment": "required",
+          "operator_questions": [
+            "Confirm whether Group of Five CFBStats ranking context renders acceptably in the brief.",
+            "Record any StatBroadcast discovery differences for non-Power teams."
+          ]
+        }
+      ]
+    },
+    {
+      "id": "wave2-any-request-drills",
+      "label": "Any-request production drills",
+      "objective": "After wave1, simulate client requests with two teams that were both missing before the request.",
+      "matchups": [
+        {
+          "id": "two-new-power-teams",
+          "status": "deferred",
+          "teams": [
+            "TBD Power Team A",
+            "TBD Power Team B"
+          ],
+          "coverage": [
+            "two missing teams",
+            "same-conference or cross-conference",
+            "24-hour turnaround drill"
+          ],
+          "pff_enrichment": "required",
+          "operator_questions": [
+            "Choose this from an actual client-like request after at least two wave1 teams are production-ready."
+          ]
+        },
+        {
+          "id": "two-new-g5-or-fcs-edge-teams",
+          "status": "deferred",
+          "teams": [
+            "TBD G5 Team A",
+            "TBD G5 Team B"
+          ],
+          "coverage": [
+            "two missing teams",
+            "Group of Five",
+            "source-discovery stress test"
+          ],
+          "pff_enrichment": "required",
+          "operator_questions": [
+            "Use only after the Mountain West or another Group of Five sample has exposed the likely discovery issues."
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/d1-matchup-expansion-plan.md
+++ b/docs/d1-matchup-expansion-plan.md
@@ -248,6 +248,52 @@ Recommended sequence:
 5. Broader FBS.
 6. FCS only after source coverage and validation behavior are understood.
 
+## Expansion Control
+
+The machine-readable plan lives in:
+
+```text
+config/d1-matchup-expansion-2025.json
+```
+
+It separates completed proofs from future onboarding targets. The current waves
+are:
+
+- Wave 0: completed proofs, currently Michigan vs Utah and Notre Dame vs UConn.
+- Wave 1: next onboarding targets, currently Michigan vs Texas, Notre Dame vs
+  Miami (FL), Utah vs BYU, and Michigan vs Boise State.
+- Wave 2: deferred any-request drills with two teams that were both missing
+  before the request.
+
+Run the plan validator from `pbp-analysis`:
+
+```bash
+python -m scripts.game_prep_brief.d1_expansion_plan \
+  --plan config/d1-matchup-expansion-2025.json \
+  --readiness-registry config/team-readiness-2025.json \
+  --markdown-out docs/d1-matchup-expansion-report.md
+```
+
+The report should have zero fail checks. Warning findings are expected for
+planned teams that are intentionally not yet in the readiness registry.
+
+For each Wave 1 target:
+
+1. Confirm expected completed games and CFBStats conference scope.
+2. Backfill StatBroadcast artifacts if the team is missing from the bundle.
+3. Generate or refresh CFBStats snapshot and verification artifacts.
+4. Refresh PFF enrichment and classify any partial provider fields.
+5. Run selected-matchup preflight and render.
+6. Quality-review the brief.
+7. Promote the team in `config/team-readiness-2025.json` only after evidence is
+   production-ready.
+8. Move the matchup status in `config/d1-matchup-expansion-2025.json` from
+   `next` or `planned` to `complete`.
+
+Keep one or two teams actively onboarding at a time. The goal is to expose and
+document failure modes, not to make the registry look bigger before the evidence
+is there.
+
 ## Issue Log Template
 
 When a reroute is needed, record it in the delivery checklist or readiness

--- a/docs/d1-matchup-expansion-report.md
+++ b/docs/d1-matchup-expansion-report.md
@@ -1,0 +1,40 @@
+# D1 Matchup Expansion Report
+
+Plan: `config/d1-matchup-expansion-2025.json`
+Readiness registry: `config/team-readiness-2025.json`
+Status: `ready`
+
+## Summary
+
+- Waves: `3`
+- Matchups: `8`
+- Teams touched: `12`
+- Pass: `38`
+- Warning: `8`
+- Fail: `0`
+
+## Matchups
+
+| Wave | Matchup | Status | Readiness | Teams | Coverage |
+| --- | --- | --- | --- | --- | --- |
+| wave0-current-proofs | michigan-utah | complete | ready | Michigan vs Utah | Big Ten, Big 12, cross-conference, non-Big-Ten team, PFF partial acceptable with notes |
+| wave0-current-proofs | notre-dame-uconn | complete | ready | Notre Dame vs UConn | Independents, alias handling, PFF partial acceptable with notes, non-Big-Ten matchup |
+| wave1-next-onboarding | michigan-texas | next | needs_onboarding | Michigan vs Texas | Big Ten, SEC, high-profile cross-conference, new PFF slug, full-season backfill from missing registry team |
+| wave1-next-onboarding | notre-dame-miami-fl | next | needs_onboarding | Notre Dame vs Miami (FL) | Independents, ACC, ambiguous team name, independent comparison policy |
+| wave1-next-onboarding | utah-byu | planned | needs_onboarding | Utah vs BYU | Big 12, no Big Ten team, rivalry naming, conference-only matchup |
+| wave1-next-onboarding | michigan-boise-state | planned | needs_onboarding | Michigan vs Boise State | Big Ten, Mountain West, Group of Five, new PFF slug |
+| wave2-any-request-drills | two-new-power-teams | deferred | needs_onboarding | TBD Power Team A vs TBD Power Team B | two missing teams, same-conference or cross-conference, 24-hour turnaround drill |
+| wave2-any-request-drills | two-new-g5-or-fcs-edge-teams | deferred | needs_onboarding | TBD G5 Team A vs TBD G5 Team B | two missing teams, Group of Five, source-discovery stress test |
+
+## Findings
+
+| Status | Wave | Matchup | Team | Check | Message |
+| --- | --- | --- | --- | --- | --- |
+| warning | wave1-next-onboarding | michigan-texas | Texas | readiness_entry | team is missing from readiness registry. |
+| warning | wave1-next-onboarding | notre-dame-miami-fl | Miami (FL) | readiness_entry | team is missing from readiness registry. |
+| warning | wave1-next-onboarding | utah-byu | BYU | readiness_entry | team is missing from readiness registry. |
+| warning | wave1-next-onboarding | michigan-boise-state | Boise State | readiness_entry | team is missing from readiness registry. |
+| warning | wave2-any-request-drills | two-new-power-teams | TBD Power Team A | readiness_entry | team is missing from readiness registry. |
+| warning | wave2-any-request-drills | two-new-power-teams | TBD Power Team B | readiness_entry | team is missing from readiness registry. |
+| warning | wave2-any-request-drills | two-new-g5-or-fcs-edge-teams | TBD G5 Team A | readiness_entry | team is missing from readiness registry. |
+| warning | wave2-any-request-drills | two-new-g5-or-fcs-edge-teams | TBD G5 Team B | readiness_entry | team is missing from readiness registry. |

--- a/scripts/game_prep_brief/d1_expansion_plan.py
+++ b/scripts/game_prep_brief/d1_expansion_plan.py
@@ -1,0 +1,460 @@
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .loaders import slugify
+from .selected_matchup import find_readiness_entry
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_PLAN = ROOT / "config" / "d1-matchup-expansion-2025.json"
+DEFAULT_REGISTRY = ROOT / "config" / "team-readiness-2025.json"
+DEFAULT_MARKDOWN = ROOT / "docs" / "d1-matchup-expansion-report.md"
+
+PASS = "pass"
+WARNING = "warning"
+FAIL = "fail"
+
+MATCHUP_STATUSES = {"complete", "next", "planned", "deferred"}
+READY_DELIVERY_STATUSES = {"ready", "ready_with_warnings"}
+REQUIRED_COMPLETE_MAPS = ("expected_games", "expected_conference")
+
+
+@dataclass(frozen=True)
+class ExpansionCheck:
+    status: str
+    wave_id: str | None
+    matchup_id: str | None
+    team: str | None
+    check: str
+    message: str
+
+    def to_dict(self) -> dict[str, str | None]:
+        return {
+            "status": self.status,
+            "wave_id": self.wave_id,
+            "matchup_id": self.matchup_id,
+            "team": self.team,
+            "check": self.check,
+            "message": self.message,
+        }
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected JSON object: {path}")
+    return payload
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _team_names(matchup: dict[str, Any]) -> list[str]:
+    teams = matchup.get("teams")
+    if isinstance(teams, list):
+        names = [team for team in teams if isinstance(team, str) and team.strip()]
+        if names:
+            return names
+    names = []
+    for field in ("team1", "team2"):
+        value = matchup.get(field)
+        if isinstance(value, str) and value.strip():
+            names.append(value)
+    return names
+
+
+def _expected_value(mapping: dict[str, Any], team_name: str) -> Any:
+    variants = {team_name, slugify(team_name)}
+    for key, value in mapping.items():
+        if not isinstance(key, str):
+            continue
+        if key in variants or slugify(key) in variants:
+            return value
+    return None
+
+
+def _readiness_status(entry: dict[str, Any]) -> str:
+    return str(entry.get("status") or "").strip()
+
+
+def _readiness_level(entry: dict[str, Any], *, strict: bool) -> tuple[str, str]:
+    status = _readiness_status(entry)
+    deliverable_status = str(entry.get("deliverable_status") or "").strip().lower()
+    if "blocked" in deliverable_status:
+        return FAIL, f"deliverable_status is {deliverable_status}."
+    if status.startswith("production_ready") and deliverable_status in READY_DELIVERY_STATUSES:
+        return PASS, f"readiness status is {status}."
+    if status.startswith("production_ready"):
+        return WARNING, f"readiness status is {status}, but deliverable_status is {deliverable_status or 'missing'}."
+    if status == "existing_supported":
+        return WARNING, "team is existing-supported, but not fully production-ready in the registry."
+    if strict:
+        return FAIL, f"readiness status is {status or 'missing'}."
+    return WARNING, f"team still needs production-ready registry evidence; current status is {status or 'missing'}."
+
+
+def _check_complete_expectations(
+    *,
+    wave_id: str,
+    matchup_id: str,
+    matchup: dict[str, Any],
+    team_name: str,
+    entry: dict[str, Any],
+) -> list[ExpansionCheck]:
+    checks: list[ExpansionCheck] = []
+    expected_games = _as_dict(matchup.get("expected_games"))
+    expected_conference = _as_dict(matchup.get("expected_conference"))
+
+    expected_game_count = _expected_value(expected_games, team_name)
+    registry_games = _as_dict(entry.get("statbroadcast")).get("expected_games")
+    if expected_game_count is None:
+        checks.append(
+            ExpansionCheck(FAIL, wave_id, matchup_id, team_name, "expected_games", "complete matchup is missing expected games.")
+        )
+    elif registry_games == expected_game_count:
+        checks.append(
+            ExpansionCheck(PASS, wave_id, matchup_id, team_name, "expected_games", f"expected games match registry ({registry_games}).")
+        )
+    else:
+        checks.append(
+            ExpansionCheck(
+                FAIL,
+                wave_id,
+                matchup_id,
+                team_name,
+                "expected_games",
+                f"plan expected {expected_game_count}; registry expected {registry_games}.",
+            )
+        )
+
+    expected_scope = _expected_value(expected_conference, team_name)
+    registry_scope = _as_dict(entry.get("cfbstats")).get("conference_scope")
+    if expected_scope is None:
+        checks.append(
+            ExpansionCheck(
+                FAIL,
+                wave_id,
+                matchup_id,
+                team_name,
+                "expected_conference",
+                "complete matchup is missing expected CFBStats conference scope.",
+            )
+        )
+    elif registry_scope == expected_scope:
+        checks.append(
+            ExpansionCheck(
+                PASS,
+                wave_id,
+                matchup_id,
+                team_name,
+                "expected_conference",
+                f"expected conference scope matches registry ({registry_scope}).",
+            )
+        )
+    else:
+        checks.append(
+            ExpansionCheck(
+                FAIL,
+                wave_id,
+                matchup_id,
+                team_name,
+                "expected_conference",
+                f"plan expected {expected_scope}; registry has {registry_scope}.",
+            )
+        )
+    return checks
+
+
+def validate_expansion_plan(
+    plan: dict[str, Any],
+    *,
+    registry: dict[str, Any] | None = None,
+    registry_path: Path | None = None,
+) -> dict[str, Any]:
+    checks: list[ExpansionCheck] = []
+    matchups_summary: list[dict[str, Any]] = []
+    seen_teams: set[str] = set()
+
+    season = plan.get("season")
+    if not isinstance(season, int):
+        checks.append(ExpansionCheck(FAIL, None, None, None, "season", "plan season must be numeric."))
+
+    waves = _as_list(plan.get("waves"))
+    if not waves:
+        checks.append(ExpansionCheck(FAIL, None, None, None, "waves", "plan must include at least one wave."))
+
+    for wave in waves:
+        if not isinstance(wave, dict):
+            checks.append(ExpansionCheck(FAIL, None, None, None, "wave", "wave entries must be objects."))
+            continue
+        wave_id = str(wave.get("id") or "").strip()
+        if not wave_id:
+            wave_id = "missing-wave-id"
+            checks.append(ExpansionCheck(FAIL, None, None, None, "wave.id", "wave id is missing."))
+
+        matchups = _as_list(wave.get("matchups"))
+        if not matchups:
+            checks.append(ExpansionCheck(FAIL, wave_id, None, None, "matchups", "wave must include matchups."))
+            continue
+
+        for matchup in matchups:
+            if not isinstance(matchup, dict):
+                checks.append(ExpansionCheck(FAIL, wave_id, None, None, "matchup", "matchup entries must be objects."))
+                continue
+
+            matchup_id = str(matchup.get("id") or "").strip()
+            if not matchup_id:
+                matchup_id = "missing-matchup-id"
+                checks.append(ExpansionCheck(FAIL, wave_id, None, None, "matchup.id", "matchup id is missing."))
+
+            status = str(matchup.get("status") or "").strip()
+            if status not in MATCHUP_STATUSES:
+                checks.append(
+                    ExpansionCheck(
+                        FAIL,
+                        wave_id,
+                        matchup_id,
+                        None,
+                        "matchup.status",
+                        f"matchup status must be one of {sorted(MATCHUP_STATUSES)}.",
+                    )
+                )
+            else:
+                checks.append(ExpansionCheck(PASS, wave_id, matchup_id, None, "matchup.status", f"matchup status is {status}."))
+
+            strict = status == "complete"
+            team_names = _team_names(matchup)
+            if len(team_names) != 2:
+                checks.append(ExpansionCheck(FAIL, wave_id, matchup_id, None, "teams", "matchup must include exactly two teams."))
+
+            coverage = [item for item in _as_list(matchup.get("coverage")) if isinstance(item, str) and item.strip()]
+            if coverage:
+                checks.append(ExpansionCheck(PASS, wave_id, matchup_id, None, "coverage", "coverage tags are present."))
+            else:
+                checks.append(ExpansionCheck(WARNING, wave_id, matchup_id, None, "coverage", "coverage tags are missing."))
+
+            evidence = [item for item in _as_list(matchup.get("evidence")) if isinstance(item, str) and item.strip()]
+            if strict and not evidence:
+                checks.append(ExpansionCheck(FAIL, wave_id, matchup_id, None, "evidence", "complete matchup needs evidence notes."))
+            elif evidence:
+                checks.append(ExpansionCheck(PASS, wave_id, matchup_id, None, "evidence", "evidence notes are present."))
+
+            for field in REQUIRED_COMPLETE_MAPS:
+                mapping = matchup.get(field)
+                if strict and not isinstance(mapping, dict):
+                    checks.append(ExpansionCheck(FAIL, wave_id, matchup_id, None, field, f"complete matchup needs {field}."))
+
+            missing_ready = False
+            blocked = False
+            for team_name in team_names:
+                seen_teams.add(slugify(team_name))
+                if registry is None:
+                    level = FAIL if strict else WARNING
+                    checks.append(
+                        ExpansionCheck(
+                            level,
+                            wave_id,
+                            matchup_id,
+                            team_name,
+                            "readiness_registry",
+                            f"readiness registry is unavailable: {registry_path}",
+                        )
+                    )
+                    missing_ready = True
+                    continue
+
+                match = find_readiness_entry(registry, team_name)
+                if match is None:
+                    level = FAIL if strict else WARNING
+                    checks.append(
+                        ExpansionCheck(
+                            level,
+                            wave_id,
+                            matchup_id,
+                            team_name,
+                            "readiness_entry",
+                            "team is missing from readiness registry.",
+                        )
+                    )
+                    missing_ready = True
+                    if strict:
+                        blocked = True
+                    continue
+
+                entry_key, entry = match
+                level, message = _readiness_level(entry, strict=strict)
+                checks.append(ExpansionCheck(level, wave_id, matchup_id, team_name, "readiness_status", message))
+                if level == FAIL:
+                    blocked = True
+                elif level != PASS:
+                    missing_ready = True
+
+                if strict:
+                    checks.extend(
+                        _check_complete_expectations(
+                            wave_id=wave_id,
+                            matchup_id=matchup_id,
+                            matchup=matchup,
+                            team_name=team_name,
+                            entry=entry,
+                        )
+                    )
+                else:
+                    checks.append(
+                        ExpansionCheck(
+                            PASS,
+                            wave_id,
+                            matchup_id,
+                            team_name,
+                            "readiness_entry",
+                            f"registry matched {entry_key}.",
+                        )
+                    )
+
+            if blocked:
+                readiness = "blocked"
+            elif missing_ready:
+                readiness = "needs_onboarding"
+            else:
+                readiness = "ready"
+            matchups_summary.append(
+                {
+                    "wave_id": wave_id,
+                    "id": matchup_id,
+                    "status": status,
+                    "teams": team_names,
+                    "coverage": coverage,
+                    "readiness": readiness,
+                }
+            )
+
+    status_counts = {
+        PASS: sum(1 for check in checks if check.status == PASS),
+        WARNING: sum(1 for check in checks if check.status == WARNING),
+        FAIL: sum(1 for check in checks if check.status == FAIL),
+    }
+    return {
+        "summary": {
+            "ready": status_counts[FAIL] == 0,
+            "status": "ready" if status_counts[FAIL] == 0 else "blocked",
+            "status_counts": status_counts,
+            "wave_count": len(waves),
+            "matchup_count": len(matchups_summary),
+            "team_count": len(seen_teams),
+        },
+        "matchups": matchups_summary,
+        "checks": [check.to_dict() for check in checks],
+    }
+
+
+def _display_path(path: Path | None) -> str:
+    if path is None:
+        return "not provided"
+    try:
+        return str(path.resolve().relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def render_markdown(report: dict[str, Any], *, plan_path: Path, registry_path: Path | None) -> str:
+    summary = report["summary"]
+    lines = [
+        "# D1 Matchup Expansion Report",
+        "",
+        f"Plan: `{_display_path(plan_path)}`",
+        f"Readiness registry: `{_display_path(registry_path)}`",
+        f"Status: `{summary['status']}`",
+        "",
+        "## Summary",
+        "",
+        f"- Waves: `{summary['wave_count']}`",
+        f"- Matchups: `{summary['matchup_count']}`",
+        f"- Teams touched: `{summary['team_count']}`",
+        f"- Pass: `{summary['status_counts'][PASS]}`",
+        f"- Warning: `{summary['status_counts'][WARNING]}`",
+        f"- Fail: `{summary['status_counts'][FAIL]}`",
+        "",
+        "## Matchups",
+        "",
+        "| Wave | Matchup | Status | Readiness | Teams | Coverage |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    for matchup in report["matchups"]:
+        teams = " vs ".join(matchup["teams"])
+        coverage = ", ".join(matchup["coverage"])
+        lines.append(
+            f"| {matchup['wave_id']} | {matchup['id']} | {matchup['status']} | {matchup['readiness']} | {teams} | {coverage} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Findings",
+            "",
+            "| Status | Wave | Matchup | Team | Check | Message |",
+            "| --- | --- | --- | --- | --- | --- |",
+        ]
+    )
+    finding_count = 0
+    for check in report["checks"]:
+        if check["status"] == PASS:
+            continue
+        finding_count += 1
+        message = str(check["message"]).replace("|", "\\|")
+        lines.append(
+            f"| {check['status']} | {check.get('wave_id') or ''} | {check.get('matchup_id') or ''} | "
+            f"{check.get('team') or ''} | {check['check']} | {message} |"
+        )
+    if finding_count == 0:
+        lines.append("| pass |  |  |  | expansion_plan | No warning or fail findings. |")
+    return "\n".join(lines) + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate the D1 matchup expansion plan.")
+    parser.add_argument("--plan", type=Path, default=DEFAULT_PLAN)
+    parser.add_argument("--readiness-registry", type=Path, default=DEFAULT_REGISTRY)
+    parser.add_argument("--json-out", type=Path, default=None)
+    parser.add_argument("--markdown-out", type=Path, default=DEFAULT_MARKDOWN)
+    parser.add_argument("--no-markdown", action="store_true")
+    parser.add_argument("--fail-on-warning", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    plan_path = args.plan.resolve()
+    registry_path = args.readiness_registry.resolve() if args.readiness_registry else None
+    registry = load_json(registry_path) if registry_path and registry_path.exists() else None
+    report = validate_expansion_plan(load_json(plan_path), registry=registry, registry_path=registry_path)
+
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    if not args.no_markdown:
+        args.markdown_out.parent.mkdir(parents=True, exist_ok=True)
+        args.markdown_out.write_text(
+            render_markdown(report, plan_path=plan_path, registry_path=registry_path),
+            encoding="utf-8",
+        )
+
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    if report["summary"]["status_counts"][FAIL] > 0:
+        raise SystemExit(1)
+    if args.fail_on_warning and report["summary"]["status_counts"][WARNING] > 0:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_d1_expansion_plan.py
+++ b/tests/test_d1_expansion_plan.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.game_prep_brief.d1_expansion_plan import render_markdown, validate_expansion_plan
+
+
+def _registry_team(**overrides):
+    team = {
+        "display_name": "Michigan",
+        "conference": "Big Ten",
+        "status": "production_ready_2025",
+        "deliverable_status": "ready_with_warnings",
+        "statbroadcast": {"expected_games": 13},
+        "cfbstats": {"conference_scope": "Big Ten"},
+    }
+    team.update(overrides)
+    return team
+
+
+def _plan(**matchup_overrides):
+    matchup = {
+        "id": "michigan-utah",
+        "status": "complete",
+        "team1": "Michigan",
+        "team2": "Utah",
+        "coverage": ["Big Ten", "Big 12"],
+        "expected_games": {"Michigan": 13, "Utah": 13},
+        "expected_conference": {"Michigan": "Big Ten", "Utah": "Big 12"},
+        "evidence": ["operator-approved"],
+    }
+    matchup.update(matchup_overrides)
+    return {"season": 2025, "waves": [{"id": "proof", "matchups": [matchup]}]}
+
+
+def test_validate_expansion_plan_passes_complete_ready_matchup() -> None:
+    registry = {
+        "teams": {
+            "michigan": _registry_team(),
+            "utah": _registry_team(
+                display_name="Utah",
+                conference="Big 12",
+                statbroadcast={"expected_games": 13},
+                cfbstats={"conference_scope": "Big 12"},
+            ),
+        }
+    }
+
+    report = validate_expansion_plan(_plan(), registry=registry, registry_path=Path("registry.json"))
+
+    assert report["summary"]["ready"] is True
+    assert report["summary"]["status_counts"]["fail"] == 0
+    assert report["matchups"][0]["readiness"] == "ready"
+
+
+def test_validate_expansion_plan_blocks_complete_missing_registry_team() -> None:
+    registry = {"teams": {"michigan": _registry_team()}}
+
+    report = validate_expansion_plan(_plan(), registry=registry, registry_path=Path("registry.json"))
+
+    assert report["summary"]["ready"] is False
+    assert any(
+        check["status"] == "fail"
+        and check["check"] == "readiness_entry"
+        and check["team"] == "Utah"
+        for check in report["checks"]
+    )
+
+
+def test_validate_expansion_plan_warns_for_planned_missing_registry_team() -> None:
+    registry = {"teams": {"michigan": _registry_team()}}
+
+    report = validate_expansion_plan(
+        _plan(status="planned", evidence=[], expected_games=None),
+        registry=registry,
+        registry_path=Path("registry.json"),
+    )
+
+    assert report["summary"]["ready"] is True
+    assert report["matchups"][0]["readiness"] == "needs_onboarding"
+    assert any(
+        check["status"] == "warning"
+        and check["check"] == "readiness_entry"
+        and check["team"] == "Utah"
+        for check in report["checks"]
+    )
+
+
+def test_validate_expansion_plan_blocks_complete_expected_game_mismatch() -> None:
+    registry = {
+        "teams": {
+            "michigan": _registry_team(statbroadcast={"expected_games": 12}),
+            "utah": _registry_team(
+                display_name="Utah",
+                conference="Big 12",
+                statbroadcast={"expected_games": 13},
+                cfbstats={"conference_scope": "Big 12"},
+            ),
+        }
+    }
+
+    report = validate_expansion_plan(_plan(), registry=registry, registry_path=Path("registry.json"))
+
+    assert report["summary"]["ready"] is False
+    assert any(
+        check["status"] == "fail"
+        and check["check"] == "expected_games"
+        and check["team"] == "Michigan"
+        for check in report["checks"]
+    )
+
+
+def test_render_markdown_lists_matchups_and_findings() -> None:
+    report = validate_expansion_plan(
+        _plan(status="planned", evidence=[], expected_games=None),
+        registry={"teams": {"michigan": _registry_team()}},
+        registry_path=Path("registry.json"),
+    )
+
+    markdown = render_markdown(report, plan_path=Path("plan.json"), registry_path=Path("registry.json"))
+
+    assert "# D1 Matchup Expansion Report" in markdown
+    assert "| proof | michigan-utah | planned | needs_onboarding | Michigan vs Utah | Big Ten, Big 12 |" in markdown
+    assert "| warning | proof | michigan-utah | Utah | readiness_entry |" in markdown


### PR DESCRIPTION
## Summary
- add a machine-readable 2025 D1 matchup expansion plan with completed proof matchups and next onboarding targets
- add a validator/report command for tracking expansion readiness against the team readiness registry
- preserve the existing expansion plan doc and add the new control/reporting workflow
- add tests for complete, planned, missing-registry, and mismatch cases

## Tracking
- Opens the next onboarding queue: Michigan-Texas, Notre Dame-Miami (FL), Utah-BYU, Michigan-Boise State
- Links the independent-team ranking policy follow-up in issue #250

## Validation
- /opt/homebrew/bin/python3.13 -m scripts.game_prep_brief.d1_expansion_plan --plan config/d1-matchup-expansion-2025.json --readiness-registry config/team-readiness-2025.json --markdown-out docs/d1-matchup-expansion-report.md
- /opt/homebrew/bin/python3.13 -m pytest tests/test_d1_expansion_plan.py tests/test_readiness_registry.py tests/test_selected_matchup_operator.py tests/test_matchup_preflight.py tests/test_supported_team_readiness.py -q